### PR TITLE
C# 8 and nullable reference types

### DIFF
--- a/PoESkillTree.Engine.Computation.Builders.Tests/Actions/ActionBuilderTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Actions/ActionBuilderTest.cs
@@ -100,13 +100,13 @@ namespace PoESkillTree.Engine.Computation.Builders.Actions
         public void ResolveRecentlyBuildsToCorrectResult()
         {
             var identityBuilder = CoreBuilder.Create("test");
-            var unresolvedIdentityBuilder = Mock.Of<ICoreBuilder<string>>(b => b.Resolve(null) == identityBuilder);
+            var unresolvedIdentityBuilder = Mock.Of<ICoreBuilder<string>>(b => b.Resolve(null!) == identityBuilder);
             var lastOccurenceStat = new Stat("test.LastOccurrence");
             var context = Mock.Of<IValueCalculationContext>(c =>
                 c.GetValue(lastOccurenceStat, NodeType.Total, PathDefinition.MainPath) == new NodeValue(1));
             var sut = CreateSut(unresolvedIdentityBuilder);
 
-            var result = sut.Resolve(null).Recently.Build();
+            var result = sut.Resolve(null!).Recently.Build();
             var actual = result.Value.Calculate(context);
 
             Assert.IsTrue(actual.IsTrue());
@@ -116,13 +116,13 @@ namespace PoESkillTree.Engine.Computation.Builders.Actions
         public void RecentlyResolveBuildsToCorrectResult()
         {
             var identityBuilder = CoreBuilder.Create("test");
-            var unresolvedIdentityBuilder = Mock.Of<ICoreBuilder<string>>(b => b.Resolve(null) == identityBuilder);
+            var unresolvedIdentityBuilder = Mock.Of<ICoreBuilder<string>>(b => b.Resolve(null!) == identityBuilder);
             var lastOccurenceStat = new Stat("test.LastOccurrence");
             var context = Mock.Of<IValueCalculationContext>(c =>
                 c.GetValue(lastOccurenceStat, NodeType.Total, PathDefinition.MainPath) == new NodeValue(1));
             var sut = CreateSut(unresolvedIdentityBuilder);
 
-            var result = sut.Recently.Resolve(null).Build();
+            var result = sut.Recently.Resolve(null!).Build();
             var actual = result.Value.Calculate(context);
 
             Assert.IsTrue(actual.IsTrue());
@@ -163,10 +163,10 @@ namespace PoESkillTree.Engine.Computation.Builders.Actions
         public void OnResolvesIdentity()
         {
             var identityBuilder = CoreBuilder.Create("test");
-            var unresolvedBuilder = Mock.Of<ICoreBuilder<string>>(b => b.Resolve(null) == identityBuilder);
+            var unresolvedBuilder = Mock.Of<ICoreBuilder<string>>(b => b.Resolve(null!) == identityBuilder);
             var sut = CreateSut(unresolvedBuilder);
 
-            var result = sut.On.Resolve(null).Build();
+            var result = sut.On.Resolve(null!).Build();
             var stat = result.StatConverter(InputStat).BuildToSingleStat();
 
             Assert.AreEqual("stat.On(test).By(Character)", stat.Identity);
@@ -176,6 +176,6 @@ namespace PoESkillTree.Engine.Computation.Builders.Actions
             new ActionBuilder(new StatFactory(), identity ?? CoreBuilder.Create("test"),
                 entity ?? new ModifierSourceEntityBuilder());
 
-        private static IStatBuilder InputStat => StatBuilderUtils.FromIdentity(new StatFactory(), "stat", null);
+        private static IStatBuilder InputStat => StatBuilderUtils.FromIdentity(new StatFactory(), "stat", typeof(double));
     }
 }

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Actions/ActionBuilderTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Actions/ActionBuilderTest.cs
@@ -172,7 +172,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Actions
             Assert.AreEqual("stat.On(test).By(Character)", stat.Identity);
         }
 
-        private static ActionBuilder CreateSut(ICoreBuilder<string> identity = null, IEntityBuilder entity = null) =>
+        private static ActionBuilder CreateSut(ICoreBuilder<string>? identity = null, IEntityBuilder? entity = null) =>
             new ActionBuilder(new StatFactory(), identity ?? CoreBuilder.Create("test"),
                 entity ?? new ModifierSourceEntityBuilder());
 

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Actions/ActionBuildersTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Actions/ActionBuildersTest.cs
@@ -67,7 +67,8 @@ namespace PoESkillTree.Engine.Computation.Builders.Actions
         private static ActionBuilders CreateSut() =>
             new ActionBuilders(StatFactory);
 
-        private static readonly IStatBuilder InputStat = StatBuilderUtils.FromIdentity(new StatFactory(), "stat", null);
+        private static readonly IStatBuilder InputStat =
+            StatBuilderUtils.FromIdentity(new StatFactory(), "stat", typeof(double));
         private static readonly IStatFactory StatFactory = new StatFactory();
     }
 }

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Behaviors/RegenUncappedSubtotalValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Behaviors/RegenUncappedSubtotalValueTest.cs
@@ -108,10 +108,9 @@ namespace PoESkillTree.Engine.Computation.Builders.Behaviors
         private static NodeValue TargetValueFor(Pool pool) => new NodeValue((double) pool);
         private static PathDefinition Path => PathDefinition.MainPath;
 
-        private static RegenUncappedSubtotalValue CreateSut(IValue transformedValue = null)
+        private static RegenUncappedSubtotalValue CreateSut(IValue? transformedValue = null)
         {
-            transformedValue = transformedValue ??
-                new FunctionalValue(c => c.GetValues(Regen(Pool.Life), NodeType.PathTotal).Sum(), "");
+            transformedValue ??= new FunctionalValue(c => c.GetValues(Regen(Pool.Life), NodeType.PathTotal).Sum(), "");
             return new RegenUncappedSubtotalValue(Pool.Life, Regen, TargetPool, transformedValue);
         }
     }

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Behaviors/RequirementUncappedSubtotalValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Behaviors/RequirementUncappedSubtotalValueTest.cs
@@ -17,7 +17,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Behaviors
             var expected = (NodeValue?) values.Max();
             var transformedStat = new Stat("transformed");
             var paths = values
-                .Select((_, i) => new PathDefinition(new ModifierSource.Local.Gem(ItemSlot.Helm, i)))
+                .Select((_, i) => new PathDefinition(new ModifierSource.Local.Gem(ItemSlot.Helm, i, "")))
                 .ToList();
             var contextMock = new Mock<IValueCalculationContext>();
             contextMock.Setup(c => c.GetPaths(transformedStat)).Returns(paths);

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Behaviors/RoundedValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Behaviors/RoundedValueTest.cs
@@ -13,7 +13,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Behaviors
         {
             var sut = new RoundedValue(new Constant(input), decimals);
 
-            return sut.Calculate(null).SingleOrNull();
+            return sut.Calculate(null!).SingleOrNull();
         }
     }
 }

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Buffs/BuffBuilderCollectionTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Buffs/BuffBuilderCollectionTest.cs
@@ -33,7 +33,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Buffs
         [Test]
         public void AddStatBuildsToCorrectResult()
         {
-            var addedStat = StatBuilderUtils.FromIdentity(StatFactory, "s", null);
+            var addedStat = StatBuilderUtils.FromIdentity(StatFactory, "s", typeof(double));
             var sut = CreateSut(3);
 
             var stats = sut.AddStat(addedStat).BuildToStats();
@@ -46,10 +46,10 @@ namespace PoESkillTree.Engine.Computation.Builders.Buffs
         public void ResolveEffectBuildsToCorrectResult()
         {
             var buff = new BuffBuilder(StatFactory, CoreBuilder.Create("b"));
-            var unresolvedBuff = Mock.Of<IBuffBuilder>(b => b.Resolve(null) == buff);
+            var unresolvedBuff = Mock.Of<IBuffBuilder>(b => b.Resolve(null!) == buff);
             var sut = CreateSut(unresolvedBuff);
 
-            var resolved = (IBuffBuilderCollection) sut.Resolve(null);
+            var resolved = (IBuffBuilderCollection) sut.Resolve(null!);
             var stats = resolved.Effect.BuildToSingleResult().Stats;
 
             Assert.AreEqual($"b.EffectOn({default(Entity)})", stats[0].Identity);
@@ -95,10 +95,10 @@ namespace PoESkillTree.Engine.Computation.Builders.Buffs
         public void WithResolveEffectBuildsToCorrectResult()
         {
             var keyword = KeywordBuilder(1);
-            var unresolved = Mock.Of<IKeywordBuilder>(b => b.Resolve(null) == keyword);
+            var unresolved = Mock.Of<IKeywordBuilder>(b => b.Resolve(null!) == keyword);
             var sut = CreateSut(3);
 
-            var resolved = (IBuffBuilderCollection) sut.With(unresolved).Resolve(null);
+            var resolved = (IBuffBuilderCollection) sut.With(unresolved).Resolve(null!);
             var stats = resolved.Effect.BuildToStats();
 
             Assert.That(stats, Has.Exactly(2).Items);
@@ -108,10 +108,10 @@ namespace PoESkillTree.Engine.Computation.Builders.Buffs
         public void WithoutResolveEffectBuildsToCorrectResult()
         {
             var keyword = KeywordBuilder(1);
-            var unresolved = Mock.Of<IKeywordBuilder>(b => b.Resolve(null) == keyword);
+            var unresolved = Mock.Of<IKeywordBuilder>(b => b.Resolve(null!) == keyword);
             var sut = CreateSut(3);
 
-            var resolved = (IBuffBuilderCollection) sut.Without(unresolved).Resolve(null);
+            var resolved = (IBuffBuilderCollection) sut.Without(unresolved).Resolve(null!);
             var stats = resolved.Effect.BuildToSingleResult().Stats;
 
             Assert.That(stats, Has.Exactly(1).Items);
@@ -121,10 +121,10 @@ namespace PoESkillTree.Engine.Computation.Builders.Buffs
         public void WithEffectResolveBuildsToCorrectResult()
         {
             var keyword = KeywordBuilder(1);
-            var unresolved = Mock.Of<IKeywordBuilder>(b => b.Resolve(null) == keyword);
+            var unresolved = Mock.Of<IKeywordBuilder>(b => b.Resolve(null!) == keyword);
             var sut = CreateSut(3);
 
-            var resolved = sut.With(unresolved).Effect.Resolve(null);
+            var resolved = sut.With(unresolved).Effect.Resolve(null!);
             var stats = resolved.BuildToStats();
 
             Assert.That(stats, Has.Exactly(2).Items);
@@ -194,7 +194,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Buffs
         public void AnyResolveBuildsToCorrectResult()
         {
             var keyword = KeywordBuilder(2);
-            var unresolved = Mock.Of<IKeywordBuilder>(b => b.Resolve(null) == keyword);
+            var unresolved = Mock.Of<IKeywordBuilder>(b => b.Resolve(null!) == keyword);
             var activeStat = StatFactory.BuffIsActive(default, "b0");
             var sourceStat = StatFactory.BuffSourceIs(default, default, "b0");
             var context = Mock.Of<IValueCalculationContext>(c =>
@@ -203,7 +203,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Buffs
             var sut = CreateSut(1);
 
             var any = sut.With(unresolved).Any();
-            var result = any.Resolve(null).Build();
+            var result = any.Resolve(null!).Build();
             var actual = result.Value.Calculate(context);
 
             Assert.IsFalse(actual.IsTrue());

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Buffs/BuffBuilderTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Buffs/BuffBuilderTest.cs
@@ -34,7 +34,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Buffs
         {
             var expectedStat = "stat";
             var expectedValue = (NodeValue?) 3;
-            var statBuilder = StatBuilderUtils.FromIdentity(StatFactory, expectedStat, null);
+            var statBuilder = StatBuilderUtils.FromIdentity(StatFactory, expectedStat, typeof(double));
             var valueBuilder = new ValueBuilderImpl(2);
             var activeStat = new Stat("test.Active");
             var buffActiveStat = new Stat("test.BuffActive");
@@ -61,7 +61,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Buffs
         {
             var expectedStat = "stat";
             var expectedValue = (NodeValue?) 2;
-            var statBuilder = StatBuilderUtils.FromIdentity(StatFactory, expectedStat, null);
+            var statBuilder = StatBuilderUtils.FromIdentity(StatFactory, expectedStat, typeof(double));
             var valueBuilder = new ValueBuilderImpl(2);
             var activeStat = new Stat("test.Active");
             var buffActiveStat = new Stat("test.BuffActive");
@@ -83,8 +83,8 @@ namespace PoESkillTree.Engine.Computation.Builders.Buffs
         public void AddStatResolveResolvesIdentity()
         {
             var expectedIdentity = "buff";
-            var statBuilder = StatBuilderUtils.FromIdentity(StatFactory, "stat", null);
-            var resolveContext = new ResolveContext(null, null);
+            var statBuilder = StatBuilderUtils.FromIdentity(StatFactory, "stat", typeof(double));
+            var resolveContext = new ResolveContext(null!, null!);
             var sut = new BuffBuilder(StatFactory, new UnresolvedCoreBuilder<string>("unresolved",
                 c => CoreBuilder.Create(expectedIdentity)));
 

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Buffs/BuffBuildersTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Buffs/BuffBuildersTest.cs
@@ -23,7 +23,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Buffs
         public void TemporaryBuildsToCorrectResult(bool expectedCondition)
         {
             var expectedValue = expectedCondition ? (NodeValue?) 3 : null;
-            var gainedStatBuilder = StatBuilderUtils.FromIdentity(StatFactory, "s", null);
+            var gainedStatBuilder = StatBuilderUtils.FromIdentity(StatFactory, "s", typeof(double));
             var modifierSource = new ModifierSource.Local.Skill("skill node", "");
             var conditionStat = new Stat($"Is {modifierSource.SourceName} active?");
             var buffEffectStat = new Stat($"Buff.EffectOn({default(Entity)})");
@@ -66,7 +66,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Buffs
         [Test]
         public void BuffBuildsToCorrectResult()
         {
-            var gainedStatBuilder = StatBuilderUtils.FromIdentity(StatFactory, "s", null);
+            var gainedStatBuilder = StatBuilderUtils.FromIdentity(StatFactory, "s", typeof(double));
             var entityBuilders = new IEntityBuilder[]
                 { new ModifierSourceEntityBuilder(), new EntityBuilder(Entity.Enemy), };
             var buffEffectStats = new[]
@@ -94,7 +94,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Buffs
         [Test]
         public void AuraBuildsToCorrectResults()
         {
-            var gainedStatBuilder = StatBuilderUtils.FromIdentity(StatFactory, "s", null);
+            var gainedStatBuilder = StatBuilderUtils.FromIdentity(StatFactory, "s", typeof(double));
             var auraEffectStat = new Stat($"Aura.EffectOn({Entity.Minion})", Entity.Enemy);
             var context = Mock.Of<IValueCalculationContext>(c =>
                 c.GetValue(auraEffectStat, NodeType.Total, PathDefinition.MainPath) == new NodeValue(1.5));
@@ -102,7 +102,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Buffs
 
             var auraStatBuilder = sut.Aura(gainedStatBuilder, new EntityBuilder(Entity.Minion));
             var (stats, _, valueConverter) = auraStatBuilder.BuildToSingleResult(entity: Entity.Enemy);
-            var value = valueConverter(new ValueBuilderImpl(2)).Build(new BuildParameters(null, Entity.Enemy, default));
+            var value = valueConverter(new ValueBuilderImpl(2)).Build(new BuildParameters(null!, Entity.Enemy, default));
             var actualValue = value.Calculate(context);
 
             Assert.That(stats, Has.Exactly(1).Items);

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Conditions/AndCompositeConditionBuilderTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Conditions/AndCompositeConditionBuilderTest.cs
@@ -17,10 +17,10 @@ namespace PoESkillTree.Engine.Computation.Builders.Conditions
         public void ResolveResolvesConditions()
         {
             var expected = Helper.MockMany<IConditionBuilder>();
-            var input = expected.Select(c => Mock.Of<IConditionBuilder>(b => b.Resolve(null) == c));
+            var input = expected.Select(c => Mock.Of<IConditionBuilder>(b => b.Resolve(null!) == c));
             var sut = CreateSut(input);
 
-            var actual = sut.Resolve(null);
+            var actual = sut.Resolve(null!);
 
             Assert.IsInstanceOf<AndCompositeConditionBuilder>(actual);
             Assert.AreEqual(expected, ((AndCompositeConditionBuilder) actual).Conditions);
@@ -66,8 +66,8 @@ namespace PoESkillTree.Engine.Computation.Builders.Conditions
             var stats = Helper.MockMany<IStatBuilder>();
             var converters = new (StatConverter, IValue)[]
             {
-                (s => s == stats[0] ? stats[1] : null, new Constant(1)),
-                (s => s == stats[1] ? stats[2] : null, new Constant(1)),
+                (s => s == stats[0] ? stats[1] : s, new Constant(1)),
+                (s => s == stats[1] ? stats[2] : s, new Constant(1)),
             };
             var condition1 = new Mock<IConditionBuilder>();
             condition1.Setup(c => c.Build(default)).Returns(converters[0]);
@@ -94,7 +94,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Conditions
             };
             var sut = CreateSut(conditions);
 
-            var actual = sut.Build().Value.Calculate(null);
+            var actual = sut.Build().Value.Calculate(null!);
 
             Assert.AreEqual(expected, actual);
         }

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Conditions/ConditionBuildersTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Conditions/ConditionBuildersTest.cs
@@ -41,7 +41,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Conditions
 
             var value = sut.For(Mock.Of<IEntityBuilder>()).Build().Value;
 
-            Assert.IsTrue(value.Calculate(null).IsTrue());
+            Assert.IsTrue(value.Calculate(null!).IsTrue());
         }
 
         [Test]
@@ -50,7 +50,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Conditions
             var slot = ItemSlot.Amulet;
             var expected = new ModifierSource.Local.Item(slot);
             var expectedParameters = new BuildParameters(expected, default, default);
-            var result = new StatBuilderResult(new IStat[0], expected, null);
+            var result = new StatBuilderResult(new IStat[0], expected, null!);
             var inStat = Mock.Of<IStatBuilder>(b => b.Build(expectedParameters) == new[] { result });
             var sut = CreateSut();
 

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Conditions/OrCompositeConditionBuilderTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Conditions/OrCompositeConditionBuilderTest.cs
@@ -17,10 +17,10 @@ namespace PoESkillTree.Engine.Computation.Builders.Conditions
         public void ResolveResolvesConditions()
         {
             var expected = Helper.MockMany<IConditionBuilder>();
-            var input = expected.Select(c => Mock.Of<IConditionBuilder>(b => b.Resolve(null) == c));
+            var input = expected.Select(c => Mock.Of<IConditionBuilder>(b => b.Resolve(null!) == c));
             var sut = CreateSut(input);
 
-            var actual = sut.Resolve(null);
+            var actual = sut.Resolve(null!);
 
             Assert.IsInstanceOf<OrCompositeConditionBuilder>(actual);
             Assert.AreEqual(expected, ((OrCompositeConditionBuilder) actual).Conditions);
@@ -73,7 +73,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Conditions
             };
             var sut = CreateSut(conditions);
 
-            var actual = sut.Build().Value.Calculate(null);
+            var actual = sut.Build().Value.Calculate(null!);
             Assert.AreEqual(expected, actual);
         }
 
@@ -85,9 +85,9 @@ namespace PoESkillTree.Engine.Computation.Builders.Conditions
             Mock.Get(stats[1]).Setup(s => s.Concat(stats[2])).Returns(expected);
             var converters = new (StatConverter, IValue)[]
             {
-                (s => s == stats[0] ? stats[1] : null, new Constant(1)),
+                (s => s == stats[0] ? stats[1] : s, new Constant(1)),
                 (s => s, new Constant(1)),
-                (s => s == stats[0] ? stats[2] : null, new Constant(1)),
+                (s => s == stats[0] ? stats[2] : s, new Constant(1)),
             };
             var conditions = converters.Select(CreateCondition);
             var sut = CreateSut(conditions);

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Conditions/ValueConditionBuilderTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Conditions/ValueConditionBuilderTest.cs
@@ -14,7 +14,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Conditions
         {
             var sut = CreateSut();
 
-            Assert.AreSame(sut, sut.Resolve(null));
+            Assert.AreSame(sut, sut.Resolve(null!));
         }
 
         [Test]
@@ -35,7 +35,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Conditions
             var expected = (NodeValue?) condition;
             var sut = CreateSut(condition);
 
-            var actual = sut.Build().Value.Calculate(null);
+            var actual = sut.Build().Value.Calculate(null!);
 
             Assert.AreEqual(expected, actual);
         }
@@ -47,7 +47,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Conditions
             var expected = (NodeValue?) !condition;
             var sut = CreateSut(condition);
 
-            var actual = sut.Not.Build().Value.Calculate(null);
+            var actual = sut.Not.Build().Value.Calculate(null!);
 
             Assert.AreEqual(expected, actual);
         }

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Effects/EffectBuilderTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Effects/EffectBuilderTest.cs
@@ -30,7 +30,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Effects
         {
             var expectedStat = "stat";
             var expectedValue = effectActive ? (NodeValue?) 2 : null;
-            var statBuilder = StatBuilderUtils.FromIdentity(new StatFactory(), expectedStat, null);
+            var statBuilder = StatBuilderUtils.FromIdentity(new StatFactory(), expectedStat, typeof(double));
             var valueBuilder = new ValueBuilderImpl(2);
             var activeStat = new Stat("test.Active");
             var context = Mock.Of<IValueCalculationContext>(c =>

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Equipment/EquipmentBuilderCollectionTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Equipment/EquipmentBuilderCollectionTest.cs
@@ -28,7 +28,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Equipment
             var expected = new NodeValue(Enum.GetValues(typeof(ItemSlot)).Length);
             var sut = CreateSut();
 
-            var actual = sut.Count().Build().Calculate(null);
+            var actual = sut.Count().Build().Calculate(null!);
 
             Assert.AreEqual(expected, actual);
         }
@@ -70,7 +70,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Equipment
         {
             var sut = CreateSut();
 
-            var actual = sut.Any().Build().Value.Calculate(null);
+            var actual = sut.Any().Build().Value.Calculate(null!);
 
             Assert.IsTrue(actual.IsTrue());
         }

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Forms/FormBuildersTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Forms/FormBuildersTest.cs
@@ -69,7 +69,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Forms
             var sut = CreateSut();
 
             var expected = sut.BaseSet;
-            var actual = expected.Resolve(null);
+            var actual = expected.Resolve(null!);
 
             Assert.AreEqual(expected, actual);
         }

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Forms/FormBuildersTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Forms/FormBuildersTest.cs
@@ -76,7 +76,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Forms
 
         private static FormBuilders CreateSut() => new FormBuilders();
 
-        private static IFormBuilder GetProperty(IFormBuilders sut, string property) =>
-            (IFormBuilder) sut.GetType().GetProperty(property).GetValue(sut);
+        private static IFormBuilder GetProperty(IFormBuilders sut, string property)
+            => (IFormBuilder) sut.GetType().GetProperty(property)!.GetValue(sut)!;
     }
 }

--- a/PoESkillTree.Engine.Computation.Builders.Tests/PoESkillTree.Engine.Computation.Builders.Tests.csproj
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/PoESkillTree.Engine.Computation.Builders.Tests.csproj
@@ -10,14 +10,14 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Enums.NET" Version="2.3.2" />
-    <PackageReference Include="Moq" Version="4.12.0" />
+    <PackageReference Include="Moq" Version="4.13.0" />
     <PackageReference Include="morelinq" Version="3.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PoESkillTree.Engine.Utils\PoESkillTree.Engine.Utils.csproj" />

--- a/PoESkillTree.Engine.Computation.Builders.Tests/PoESkillTree.Engine.Computation.Builders.Tests.csproj
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/PoESkillTree.Engine.Computation.Builders.Tests.csproj
@@ -2,11 +2,13 @@
   <PropertyGroup>
     <RootNamespace>PoESkillTree.Engine.Computation.Builders</RootNamespace>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8</LangVersion>
     <AssemblyTitle>PoESkillTree.Engine.Computation.Builders.Tests</AssemblyTitle>
     <Product>PoESkillTree.Engine.Computation.Builders.Tests</Product>
     <Copyright>Copyright ©  2018</Copyright>
     <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>8600;8601;8602;8603;8604;8619;8620</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/PoESkillTree.Engine.Computation.Builders.Tests/PoESkillTree.Engine.Computation.Builders.Tests.csproj
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/PoESkillTree.Engine.Computation.Builders.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>PoESkillTree.Engine.Computation.Builders</RootNamespace>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyTitle>PoESkillTree.Engine.Computation.Builders.Tests</AssemblyTitle>
     <Product>PoESkillTree.Engine.Computation.Builders.Tests</Product>

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Resolving/UnresolvedBuilderTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Resolving/UnresolvedBuilderTest.cs
@@ -16,7 +16,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Resolving
         [Test]
         public void ResolveUsesInjectedFunction()
         {
-            var expected = 5;
+            var expected = "5";
             var sut = CreateSut(expected);
 
             var actual = sut.Resolve(BuildersHelper.MockResolveContext());
@@ -24,7 +24,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Resolving
             Assert.AreEqual(expected, actual);
         }
 
-        private static UnresolvedBuilder<int, string> CreateSut(int resolved = 0) => 
-            new UnresolvedBuilder<int, string>("", _ => resolved);
+        private static UnresolvedBuilder<string, string> CreateSut(string resolved = "0") => 
+            new UnresolvedBuilder<string, string>("", _ => resolved);
     }
 }

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Skills/SkillBuilderCollectionTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Skills/SkillBuilderCollectionTest.cs
@@ -26,10 +26,10 @@ namespace PoESkillTree.Engine.Computation.Builders.Skills
         public void ResolveCombinedInstancesBuildsToCorrectResult()
         {
             var keywords = new[] { Keyword.Projectile };
-            var unresolved = new[] { Mock.Of<IKeywordBuilder>(b => b.Resolve(null).Build(default) == keywords[0]) };
+            var unresolved = new[] { Mock.Of<IKeywordBuilder>(b => b.Resolve(null!).Build(default) == keywords[0]) };
             var sut = CreateSut(unresolved);
 
-            var stat = sut.Resolve(null).CombinedInstances.BuildToSingleStat();
+            var stat = sut.Resolve(null!).CombinedInstances.BuildToSingleStat();
 
             Assert.AreEqual("Skills[Projectile].Instances", stat.Identity);
         }
@@ -38,10 +38,10 @@ namespace PoESkillTree.Engine.Computation.Builders.Skills
         public void CombinedInstancesResolveBuildsToCorrectResult()
         {
             var keywords = new[] { Keyword.Projectile };
-            var unresolved = new[] { Mock.Of<IKeywordBuilder>(b => b.Resolve(null).Build(default) == keywords[0]) };
+            var unresolved = new[] { Mock.Of<IKeywordBuilder>(b => b.Resolve(null!).Build(default) == keywords[0]) };
             var sut = CreateSut(unresolved);
 
-            var stat = sut.CombinedInstances.Resolve(null).BuildToSingleStat();
+            var stat = sut.CombinedInstances.Resolve(null!).BuildToSingleStat();
 
             Assert.AreEqual("Skills[Projectile].Instances", stat.Identity); 
         }

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Skills/SkillBuilderTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Skills/SkillBuilderTest.cs
@@ -18,7 +18,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Skills
             var coreBuilder = CreateCoreBuilder("", expected);
             var sut = CreateSut(coreBuilder);
 
-            var actual = sut.SkillId.Build().Calculate(null);
+            var actual = sut.SkillId.Build().Calculate(null!);
 
             Assert.AreEqual((NodeValue?) expected, actual);
         }
@@ -28,10 +28,10 @@ namespace PoESkillTree.Engine.Computation.Builders.Skills
         {
             var expected = 42;
             var coreBuilder = CreateCoreBuilder("", expected);
-            var unresolved = Mock.Of<ICoreBuilder<SkillDefinition>>(b => b.Resolve(null) == coreBuilder);
+            var unresolved = Mock.Of<ICoreBuilder<SkillDefinition>>(b => b.Resolve(null!) == coreBuilder);
             var sut = CreateSut(unresolved);
 
-            var actual = sut.SkillId.Resolve(null).Build().Calculate(null);
+            var actual = sut.SkillId.Resolve(null!).Build().Calculate(null!);
 
             Assert.AreEqual((NodeValue?) expected, actual);
         }

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Skills/SkillBuildersTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Skills/SkillBuildersTest.cs
@@ -56,7 +56,8 @@ namespace PoESkillTree.Engine.Computation.Builders.Skills
             => new SkillBuilders(new StatFactory(), new SkillDefinitions(new[] { SkillDefinition }));
         
         private static readonly SkillDefinition SkillDefinition =
-            SkillDefinition.CreateActive(SkillId, 0, "", null, null, null, null);
+            SkillDefinition.CreateActive(SkillId, 0, "", new string[0], null, null!,
+                new Dictionary<int, SkillLevelDefinition>());
 
         private const string SkillId = "skill";
     }

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Stats/CompositeCoreStatBuilderTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Stats/CompositeCoreStatBuilderTest.cs
@@ -18,12 +18,12 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
         {
             var multiResults = new[]
             {
-                new StatBuilderResult(new IStat[0], null, Funcs.Identity),
-                new StatBuilderResult(new IStat[0], null, Funcs.Identity),
+                new StatBuilderResult(new IStat[0], null!, Funcs.Identity),
+                new StatBuilderResult(new IStat[0], null!, Funcs.Identity),
             };
             var singleResults = new[]
             {
-                new StatBuilderResult(new IStat[0], null, Funcs.Identity),
+                new StatBuilderResult(new IStat[0], null!, Funcs.Identity),
             };
             var multiCoreStatBuilder = Mock.Of<ICoreStatBuilder>(b => b.Build(default) == multiResults);
             var singleCoreStatBuilder =
@@ -40,8 +40,8 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
         {            
             var itemResults = new[]
             {
-                new StatBuilderResult(new IStat[0], null, Funcs.Identity),
-                new StatBuilderResult(new IStat[0], null, Funcs.Identity),
+                new StatBuilderResult(new IStat[0], null!, Funcs.Identity),
+                new StatBuilderResult(new IStat[0], null!, Funcs.Identity),
             };
             var leftCore = Mock.Of<ICoreStatBuilder>(b => b.Build(default) == itemResults);
             var rightCore = Mock.Of<ICoreStatBuilder>(b => b.Build(default) == itemResults);

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Stats/ConversionStatBuilderTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Stats/ConversionStatBuilderTest.cs
@@ -133,14 +133,14 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
         }
 
         private static ICoreStatBuilder MockStatBuilder(
-            ModifierSource modifierSource = null, ValueConverter valueConverter = null) =>
+            ModifierSource? modifierSource = null, ValueConverter? valueConverter = null) =>
             MockStatBuilder(CreateStatBuilderResult(modifierSource, valueConverter));
 
         private static ICoreStatBuilder MockStatBuilder(params StatBuilderResult[] results) =>
             Mock.Of<ICoreStatBuilder>(b => b.Build(default) == results);
 
         private static StatBuilderResult CreateStatBuilderResult(
-            ModifierSource modifierSource = null, ValueConverter valueConverter = null, params IStat[] stats) =>
+            ModifierSource? modifierSource = null, ValueConverter? valueConverter = null, params IStat[] stats) =>
             new StatBuilderResult(stats, modifierSource, valueConverter ?? Funcs.Identity);
     }
 }

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Stats/ConversionStatBuilderTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Stats/ConversionStatBuilderTest.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using PoESkillTree.Engine.Computation.Common;
 using PoESkillTree.Engine.Computation.Common.Builders;
 using PoESkillTree.Engine.Computation.Common.Builders.Entities;
+using PoESkillTree.Engine.Computation.Common.Builders.Resolving;
 using PoESkillTree.Engine.Computation.Common.Builders.Stats;
 using PoESkillTree.Engine.Computation.Common.Builders.Values;
 using PoESkillTree.Engine.Computation.Common.Parsing;
@@ -82,12 +83,14 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
         {
             var source = new Mock<ICoreStatBuilder>();
             var target = new Mock<ICoreStatBuilder>();
+            var context = new ResolveContext(Mock.Of<IMatchContext<IValueBuilder>>(),
+                Mock.Of<IMatchContext<IReferenceConverter>>());
             var sut = CreateSut(source.Object, target.Object);
 
-            sut.Resolve(null);
+            sut.Resolve(context);
 
-            source.Verify(b => b.Resolve(null));
-            target.Verify(b => b.Resolve(null));
+            source.Verify(b => b.Resolve(context));
+            target.Verify(b => b.Resolve(context));
         }
 
         [Test]
@@ -141,6 +144,6 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
 
         private static StatBuilderResult CreateStatBuilderResult(
             ModifierSource? modifierSource = null, ValueConverter? valueConverter = null, params IStat[] stats) =>
-            new StatBuilderResult(stats, modifierSource, valueConverter ?? Funcs.Identity);
+            new StatBuilderResult(stats, modifierSource!, valueConverter ?? Funcs.Identity);
     }
 }

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Stats/DamageRelatedStatBuilderTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Stats/DamageRelatedStatBuilderTest.cs
@@ -191,10 +191,10 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
         {
             var ailment = Ailment.Bleed;
             var resolvedAilmentBuilder = Mock.Of<IAilmentBuilder>(b => b.Build(default) == ailment);
-            var ailmentBuilder = Mock.Of<IAilmentBuilder>(b => b.Resolve(null) == resolvedAilmentBuilder);
+            var ailmentBuilder = Mock.Of<IAilmentBuilder>(b => b.Resolve(null!) == resolvedAilmentBuilder);
             var sut = CreateSut();
 
-            var resolved = sut.With(ailmentBuilder).Resolve(null);
+            var resolved = sut.With(ailmentBuilder).Resolve(null!);
             var stat = BuildToStats(resolved, SkillResultCount - 1)[0];
 
             StringAssert.Contains(ailment.ToString(), stat.Identity);

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Stats/DamageStatBuilderTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Stats/DamageStatBuilderTest.cs
@@ -52,12 +52,12 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
         {
             var keyword = Keyword.Projectile;
             var keywordBuilder = Mock.Of<IKeywordBuilder>(b => b.Build(default) == keyword);
-            var unresolvedKeywordBuilder = Mock.Of<IKeywordBuilder>(b => b.Resolve(null) == keywordBuilder);
+            var unresolvedKeywordBuilder = Mock.Of<IKeywordBuilder>(b => b.Resolve(null!) == keywordBuilder);
             var valueBuilder = new ValueBuilderImpl(2);
             var context = SetupKeywordContext(keyword);
             var sut = CreateSut();
 
-            var resolved = sut.WithHits.With(unresolvedKeywordBuilder).Resolve(null);
+            var resolved = sut.WithHits.With(unresolvedKeywordBuilder).Resolve(null!);
             var results = resolved.Build(default).ToList();
 
             Assert.That(results, Has.Exactly(4).Items);

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Stats/StatBuilderAdapterTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Stats/StatBuilderAdapterTest.cs
@@ -21,9 +21,9 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
             var conditionBuilder = new Mock<IConditionBuilder>();
             var sut = new StatBuilderAdapter(statBuilder, conditionBuilder.Object);
 
-            sut.Resolve(null);
+            sut.Resolve(null!);
 
-            conditionBuilder.Verify(b => b.Resolve(null));
+            conditionBuilder.Verify(b => b.Resolve(null!));
         }
 
         [Test]

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Stats/StatBuilderHelper.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Stats/StatBuilderHelper.cs
@@ -14,25 +14,25 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
         public static ICoreStatBuilder CreateStatBuilder(string identity, params Entity[] entities) =>
             CreateStatBuilder(identity, new EntityBuilder(entities));
 
-        public static ICoreStatBuilder CreateStatBuilder(string identity, IEntityBuilder entityBuilder = null)
+        public static ICoreStatBuilder CreateStatBuilder(string identity, IEntityBuilder? entityBuilder = null)
         {
             IStat CreateStat(Entity entity) => new Stat(identity, entity);
             return new LeafCoreStatBuilder(CreateStat, entityBuilder);
         }
 
-        public static ICoreStatBuilder CreateStatBuilder(IStat stat, IEntityBuilder entityBuilder = null) =>
+        public static ICoreStatBuilder CreateStatBuilder(IStat stat, IEntityBuilder? entityBuilder = null) =>
             new LeafCoreStatBuilder(_ => stat, entityBuilder);
 
         public static IStat BuildToSingleStat(this IStatBuilder @this,
-            ModifierSource modifierSource = null, Entity entity = default) =>
+            ModifierSource? modifierSource = null, Entity entity = default) =>
             @this.BuildToSingleResult(modifierSource, entity).Stats.Single();
 
         public static StatBuilderResult BuildToSingleResult(this IStatBuilder @this,
-            ModifierSource modifierSource = null, Entity entity = default) =>
+            ModifierSource? modifierSource = null, Entity entity = default) =>
             @this.Build(new BuildParameters(modifierSource, entity, default)).Single();
 
         public static IReadOnlyList<IStat> BuildToStats(this IStatBuilder @this,
-            ModifierSource modifierSource = null, Entity entity = default) =>
+            ModifierSource? modifierSource = null, Entity entity = default) =>
             @this.Build(new BuildParameters(modifierSource, entity, default)).SelectMany(r => r.Stats).ToList();
     }
 }

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Stats/StatBuilderHelper.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Stats/StatBuilderHelper.cs
@@ -29,10 +29,10 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
 
         public static StatBuilderResult BuildToSingleResult(this IStatBuilder @this,
             ModifierSource? modifierSource = null, Entity entity = default) =>
-            @this.Build(new BuildParameters(modifierSource, entity, default)).Single();
+            @this.Build(new BuildParameters(modifierSource!, entity, default)).Single();
 
         public static IReadOnlyList<IStat> BuildToStats(this IStatBuilder @this,
             ModifierSource? modifierSource = null, Entity entity = default) =>
-            @this.Build(new BuildParameters(modifierSource, entity, default)).SelectMany(r => r.Stats).ToList();
+            @this.Build(new BuildParameters(modifierSource!, entity, default)).SelectMany(r => r.Stats).ToList();
     }
 }

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Stats/StatBuilderTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Stats/StatBuilderTest.cs
@@ -127,7 +127,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
             var context = Mock.Of<IValueCalculationContext>(c =>
                 c.GetValue(stat, NodeType.Total, PathDefinition.MainPath) == expected);
 
-            var value = sut.Value.Build(new BuildParameters(null, entity, default));
+            var value = sut.Value.Build(new BuildParameters(null!, entity, default));
             var actual = value.Calculate(context);
 
             Assert.AreEqual(expected, actual);
@@ -258,9 +258,9 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
             var otherMock = new Mock<IStatBuilder>();
 
             var combined = sut.CombineWith(otherMock.Object);
-            combined.Resolve(null);
+            combined.Resolve(null!);
 
-            otherMock.Verify(b => b.Resolve(null));
+            otherMock.Verify(b => b.Resolve(null!));
         }
 
         [Test]
@@ -324,7 +324,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
             var sutWithCondition = sut.WithCondition(condition.Object);
             var actual = sutWithCondition.BuildToSingleResult();
             var actualStat = actual.Stats.Single();
-            var actualValue = actual.ValueConverter(inputValueBuilder).Build(default).Calculate(null);
+            var actualValue = actual.ValueConverter(inputValueBuilder).Build(default).Calculate(null!);
 
             Assert.AreEqual(expectedStat, actualStat);
             Assert.AreEqual(expectedValue, actualValue);
@@ -386,7 +386,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
         public void IsSetCalculatesCorrectValue(double? input, bool expected)
         {
             var stat = new Stat("s");
-            var results = new[] { new StatBuilderResult(new[] { stat }, null, Funcs.Identity), };
+            var results = new[] { new StatBuilderResult(new[] { stat }, null!, Funcs.Identity), };
             var coreStatBuilder = Mock.Of<ICoreStatBuilder>(b => b.Build(default) == results);
             var context = Mock.Of<IValueCalculationContext>(c =>
                 c.GetValue(stat, NodeType.Total, PathDefinition.MainPath) == (NodeValue?) input);
@@ -443,7 +443,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
             var stats = stat == null ? new IStat[0] : new[] { stat };
             return new[]
             {
-                new StatBuilderResult(stats, modifierSource, valueConverter ?? Funcs.Identity)
+                new StatBuilderResult(stats, modifierSource!, valueConverter ?? Funcs.Identity)
             };
         }
 

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Stats/StatBuilderTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Stats/StatBuilderTest.cs
@@ -401,7 +401,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
         [Test]
         public void ConvertToIsNotSubClass()
         {
-            var sut = new SubStatBuilder(new StatFactory(), null);
+            var sut = new SubStatBuilder(new StatFactory(), Mock.Of<ICoreStatBuilder>());
 
             var actual = sut.ConvertTo(Mock.Of<IStatBuilder>());
 
@@ -412,7 +412,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
         [Test]
         public void GainAsIsNotSubClass()
         {
-            var sut = new SubStatBuilder(new StatFactory(), null);
+            var sut = new SubStatBuilder(new StatFactory(), Mock.Of<ICoreStatBuilder>());
 
             var actual = sut.GainAs(Mock.Of<IStatBuilder>());
 
@@ -437,8 +437,8 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
             new StatBuilder(new StatFactory(), coreStatBuilder);
 
         private static IReadOnlyList<StatBuilderResult> CreateResult(
-            IStat stat = null, ModifierSource modifierSource = null,
-            ValueConverter valueConverter = null)
+            IStat? stat = null, ModifierSource? modifierSource = null,
+            ValueConverter? valueConverter = null)
         {
             var stats = stat == null ? new IStat[0] : new[] { stat };
             return new[]

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Stats/StatFactoryTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Stats/StatFactoryTest.cs
@@ -222,7 +222,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
 
         private static T AssertTransformedValueIs<T>(Behavior actual) where T : IValue
         {
-            var value = actual.Transformation.Transform(null);
+            var value = actual.Transformation.Transform(null!);
             Assert.IsInstanceOf<T>(value);
             return (T) value;
         }

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Values/ValueBuilderTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Values/ValueBuilderTest.cs
@@ -15,7 +15,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Values
         {
             var sut = CreateSut();
 
-            Assert.AreSame(sut, sut.Resolve(null));
+            Assert.AreSame(sut, sut.Resolve(null!));
         }
 
         [Test]
@@ -36,7 +36,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Values
             var expected = new NodeValue(0, 2);
             var sut = CreateSut(value);
 
-            var actual = sut.MaximumOnly.Build().Calculate(null);
+            var actual = sut.MaximumOnly.Build().Calculate(null!);
 
             Assert.AreEqual(expected, actual);
         }
@@ -50,7 +50,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Values
         {
             var sut = CreateSut(left);
 
-            var actual = sut.Add(new ValueBuilderImpl(right)).Build().Calculate(null);
+            var actual = sut.Add(new ValueBuilderImpl(right)).Build().Calculate(null!);
 
             Assert.AreEqual((NodeValue?) expected, actual);
         }
@@ -64,7 +64,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Values
         {
             var sut = CreateSut(left);
 
-            var actual = sut.Multiply(new ValueBuilderImpl(right)).Build().Calculate(null);
+            var actual = sut.Multiply(new ValueBuilderImpl(right)).Build().Calculate(null!);
 
             Assert.AreEqual((NodeValue?) expected, actual);
         }
@@ -78,7 +78,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Values
         {
             var sut = CreateSut(left);
 
-            var actual = sut.DivideBy(new ValueBuilderImpl(right)).Build().Calculate(null);
+            var actual = sut.DivideBy(new ValueBuilderImpl(right)).Build().Calculate(null!);
 
             Assert.AreEqual((NodeValue?) expected, actual);
         }
@@ -90,7 +90,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Values
             var expected = (NodeValue?) (value is null ? (double?) null : Math.Round(value.Value));
             var sut = CreateSut(value);
 
-            var actual = sut.Select(v => v.Select(Math.Round), _ => "").Build().Calculate(null);
+            var actual = sut.Select(v => v.Select(Math.Round), _ => "").Build().Calculate(null!);
 
             Assert.AreEqual(expected, actual);
         }
@@ -102,7 +102,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Values
         {
             var sut = CreateSut(leftValue);
 
-            var actual = sut.Eq(new ValueBuilderImpl(rightValue)).Build().Value.Calculate(null);
+            var actual = sut.Eq(new ValueBuilderImpl(rightValue)).Build().Value.Calculate(null!);
 
             Assert.AreEqual((NodeValue?) expected, actual);
         }
@@ -115,7 +115,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Values
         {
             var sut = CreateSut(leftValue);
 
-            var actual = sut.GreaterThan(new ValueBuilderImpl(rightValue)).Build().Value.Calculate(null);
+            var actual = sut.GreaterThan(new ValueBuilderImpl(rightValue)).Build().Value.Calculate(null!);
 
             Assert.AreEqual((NodeValue?) expected, actual);
         }
@@ -140,7 +140,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Values
             var sut = CreateSut(leftValue);
 
             var resolved = sut.Add(right).Resolve(context);
-            var actual = resolved.Build().Calculate(null);
+            var actual = resolved.Build().Calculate(null!);
 
             Assert.AreEqual(expected, actual);
         }
@@ -150,7 +150,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Values
         {
             var sut = CreateSut().Multiply(CreateSut(new ThrowingValue()));
 
-            var actual = sut.Build().Calculate(null);
+            var actual = sut.Build().Calculate(null!);
 
             Assert.IsNull(actual);
         }
@@ -160,7 +160,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Values
         {
             var sut = CreateSut().DivideBy(CreateSut(new ThrowingValue()));
 
-            var actual = sut.Build().Calculate(null);
+            var actual = sut.Build().Calculate(null!);
 
             Assert.IsNull(actual);
         }
@@ -170,7 +170,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Values
         {
             var sut = CreateSut(new ThrowingValue()).If(new Constant(false));
 
-            var actual = sut.Build().Calculate(null);
+            var actual = sut.Build().Calculate(null!);
 
             Assert.IsNull(actual);
         }

--- a/PoESkillTree.Engine.Computation.Builders.Tests/Values/ValueBuildersTest.cs
+++ b/PoESkillTree.Engine.Computation.Builders.Tests/Values/ValueBuildersTest.cs
@@ -21,7 +21,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Values
             var maxBuilder = new ValueBuilderImpl(max);
             var sut = CreateSut();
 
-            var actual = sut.FromMinAndMax(minBuilder, maxBuilder).Build().Calculate(null);
+            var actual = sut.FromMinAndMax(minBuilder, maxBuilder).Build().Calculate(null!);
 
             Assert.AreEqual(expected, actual);
         }
@@ -40,7 +40,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Values
                 .Then(new ValueBuilderImpl(1))
                 .Else(2);
 
-            var actual = valueBuilder.Build().Calculate(null);
+            var actual = valueBuilder.Build().Calculate(null!);
             Assert.AreEqual(new NodeValue(trueBranch), actual);
         }
 

--- a/PoESkillTree.Engine.Computation.Builders/Actions/ActionBuilders.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Actions/ActionBuilders.cs
@@ -73,7 +73,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Actions
 
         public IActionBuilder Unique(string description) => Create(description);
 
-        private IActionBuilder Create([CallerMemberName] string identity = null) =>
+        private IActionBuilder Create([CallerMemberName] string identity = "") =>
             new ActionBuilder(_statFactory, CoreBuilder.Create(identity), _entity);
 
         private class ThrowingContext : IValueCalculationContext

--- a/PoESkillTree.Engine.Computation.Builders/Behaviors/BehaviorFactory.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Behaviors/BehaviorFactory.cs
@@ -172,7 +172,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Behaviors
                 new[] { NodeType.Increase, NodeType.More }, BehaviorPathRules.All,
                 v => new AilmentDamageIncreaseMoreValue(
                     _statFactory.ConcretizeDamage(stat, damageSpecification),
-                    _statFactory.AilmentDealtDamageType(stat.Entity, damageSpecification.Ailment.Value),
+                    _statFactory.AilmentDealtDamageType(stat.Entity, damageSpecification.Ailment!.Value),
                     t => _statFactory.ConcretizeDamage(_statFactory.Damage(stat.Entity, t), damageSpecification), v),
                 new CacheKey(stat, damageSpecification));
 
@@ -243,18 +243,18 @@ namespace PoESkillTree.Engine.Computation.Builders.Behaviors
             private readonly string _behaviorName;
             private readonly IReadOnlyList<object> _parameters;
 
-            public CacheKey(object parameter, [CallerMemberName] string behaviorName = null)
+            public CacheKey(object parameter, [CallerMemberName] string behaviorName = "")
                 : this(behaviorName, parameter)
             {
             }
 
-            public CacheKey(object parameter1, object parameter2, [CallerMemberName] string behaviorName = null)
+            public CacheKey(object parameter1, object parameter2, [CallerMemberName] string behaviorName = "")
                 : this(behaviorName, parameter1, parameter2)
             {
             }
 
             public CacheKey(
-                object parameter1, object parameter2, object parameter3, [CallerMemberName] string behaviorName = null)
+                object parameter1, object parameter2, object parameter3, [CallerMemberName] string behaviorName = "")
                 : this(behaviorName, parameter1, parameter2, parameter3)
             {
             }

--- a/PoESkillTree.Engine.Computation.Builders/Behaviors/ModifiedValueCalculationContext.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Behaviors/ModifiedValueCalculationContext.cs
@@ -6,9 +6,9 @@ namespace PoESkillTree.Engine.Computation.Builders.Behaviors
     internal class ModifiedValueCalculationContext : IValueCalculationContext
     {
         private readonly IValueCalculationContext _originalContext;
-        private readonly GetPathsDelegate _getPaths;
-        private readonly GetValueDelegate _getValue;
-        private readonly GetValuesDelegate _getValues;
+        private readonly GetPathsDelegate? _getPaths;
+        private readonly GetValueDelegate? _getValue;
+        private readonly GetValuesDelegate? _getValues;
 
         public delegate IReadOnlyCollection<PathDefinition> GetPathsDelegate(
             IValueCalculationContext context, IStat stat);
@@ -20,7 +20,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Behaviors
             IValueCalculationContext context, Form form, IEnumerable<(IStat stat, PathDefinition path)> paths);
 
         public ModifiedValueCalculationContext(IValueCalculationContext originalContext,
-            GetPathsDelegate getPaths = null, GetValueDelegate getValue = null, GetValuesDelegate getValues = null)
+            GetPathsDelegate? getPaths = null, GetValueDelegate? getValue = null, GetValuesDelegate? getValues = null)
         {
             _originalContext = originalContext;
             _getPaths = getPaths;

--- a/PoESkillTree.Engine.Computation.Builders/Buffs/BuffBuilders.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Buffs/BuffBuilders.cs
@@ -147,7 +147,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Buffs
                 => new StatValue(_statFactory.BuffEffect(ps.ModifierSourceEntity, target, buffIdentity));
         }
 
-        public IBuffBuilderCollection Buffs(IEntityBuilder source = null, params IEntityBuilder[] targets)
+        public IBuffBuilderCollection Buffs(IEntityBuilder? source = null, params IEntityBuilder[] targets)
         {
             var allEntitiesBuilder = EntityBuilder.AllEntities;
             var sourceEntity = source ?? allEntitiesBuilder;

--- a/PoESkillTree.Engine.Computation.Builders/Charges/ChargeTypeBuilder.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Charges/ChargeTypeBuilder.cs
@@ -33,7 +33,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Charges
         public IDamageRelatedStatBuilder ChanceToGain =>
             DamageRelatedStatBuilder.Create(_statFactory, CoreStat(typeof(uint))).WithHits;
 
-        private ICoreStatBuilder CoreStat(Type dataType, [CallerMemberName] string identitySuffix = null) =>
+        private ICoreStatBuilder CoreStat(Type dataType, [CallerMemberName] string identitySuffix = "") =>
             CoreStat((e, t) => _statFactory.FromIdentity(t.GetName() + "." + identitySuffix, e, dataType));
 
         private ICoreStatBuilder CoreStat(Func<Entity, ChargeType, IStat> statFactory) =>

--- a/PoESkillTree.Engine.Computation.Builders/Conditions/StatConvertingConditionBuilder.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Conditions/StatConvertingConditionBuilder.cs
@@ -10,18 +10,18 @@ namespace PoESkillTree.Engine.Computation.Builders.Conditions
     {
         private readonly StatConverter _statConverter;
         private readonly StatConverter _negatedStatConverter;
-        private readonly Func<ResolveContext, IConditionBuilder> _resolver;
+        private readonly Func<ResolveContext, IConditionBuilder>? _resolver;
 
         public StatConvertingConditionBuilder(
             StatConverter statConverter,
-            Func<ResolveContext, IConditionBuilder> resolver = null)
+            Func<ResolveContext, IConditionBuilder>? resolver = null)
             : this(statConverter, statConverter, resolver)
         {
         }
 
         public StatConvertingConditionBuilder(
             StatConverter statConverter, StatConverter negatedStatConverter,
-            Func<ResolveContext, IConditionBuilder> resolver = null)
+            Func<ResolveContext, IConditionBuilder>? resolver = null)
         {
             _statConverter = statConverter;
             _negatedStatConverter = negatedStatConverter;
@@ -31,7 +31,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Conditions
         public override IConditionBuilder Resolve(ResolveContext context) => _resolver?.Invoke(context) ?? this;
 
         public override IConditionBuilder Not =>
-            new StatConvertingConditionBuilder(_negatedStatConverter, _statConverter, _resolver.AndThen(b => b.Not));
+            new StatConvertingConditionBuilder(_negatedStatConverter, _statConverter, _resolver?.AndThen(b => b.Not));
 
         public override ConditionBuilderResult Build(BuildParameters parameters) =>
             new ConditionBuilderResult(_statConverter);

--- a/PoESkillTree.Engine.Computation.Builders/Conditions/ValueConditionBuilder.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Conditions/ValueConditionBuilder.cs
@@ -70,14 +70,14 @@ namespace PoESkillTree.Engine.Computation.Builders.Conditions
 
         public static IConditionBuilder Create<TParameter>(
             Func<BuildParameters, TParameter, IStat> buildStat, TParameter parameter)
-            where TParameter : IResolvable<TParameter>
+            where TParameter : class, IResolvable<TParameter>
         {
             return new ValueConditionBuilder<TParameter>((p, t) => new StatValue(buildStat(p, t)), parameter);
         }
     }
 
     public class ValueConditionBuilder<TParameter> : ConditionBuilderBase
-        where TParameter : IResolvable<TParameter>
+        where TParameter : class, IResolvable<TParameter>
     {
         private readonly Func<BuildParameters, TParameter, IValue> _buildValue;
         private readonly TParameter _parameter;
@@ -99,8 +99,8 @@ namespace PoESkillTree.Engine.Computation.Builders.Conditions
     }
 
     public class ValueConditionBuilder<TParameter1, TParameter2> : ConditionBuilderBase
-        where TParameter1 : IResolvable<TParameter1>
-        where TParameter2 : IResolvable<TParameter2>
+        where TParameter1 : class, IResolvable<TParameter1>
+        where TParameter2 : class, IResolvable<TParameter2>
     {
         private readonly Func<BuildParameters, TParameter1, TParameter2, IValue> _buildValue;
         private readonly TParameter1 _parameter1;

--- a/PoESkillTree.Engine.Computation.Builders/ConstantBuilder.cs
+++ b/PoESkillTree.Engine.Computation.Builders/ConstantBuilder.cs
@@ -15,7 +15,7 @@ namespace PoESkillTree.Engine.Computation.Builders
             _buildResult = buildResult;
         }
 
-        public TResolve Resolve(ResolveContext context) => this as TResolve;
+        public TResolve Resolve(ResolveContext context) => (this as TResolve)!;
 
         public TBuild Build() => _buildResult;
         public TBuild Build(BuildParameters parameters) => _buildResult;

--- a/PoESkillTree.Engine.Computation.Builders/Damage/DamageTypeBuilder.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Damage/DamageTypeBuilder.cs
@@ -125,7 +125,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Damage
         public IStatBuilder ReflectedDamageTaken =>
             new StatBuilder(_statFactory, CoreStat(typeof(int)));
 
-        private ICoreStatBuilder CoreStat(Type dataType, [CallerMemberName] string identitySuffix = null) =>
+        private ICoreStatBuilder CoreStat(Type dataType, [CallerMemberName] string identitySuffix = "") =>
             CoreStat((e, t) => _statFactory.FromIdentity(t.GetName() + "." + identitySuffix, e, dataType));
 
         private ICoreStatBuilder CoreStat(Func<Entity, DamageType, IStat> statFactory) =>

--- a/PoESkillTree.Engine.Computation.Builders/Effects/EffectBuilder.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Effects/EffectBuilder.cs
@@ -53,7 +53,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Effects
             stat.WithCondition(IsOn(new ModifierSourceEntityBuilder()));
 
         protected IStatBuilder FromIdentity(
-            string identitySuffix, Type dataType, ExplicitRegistrationType explicitRegistrationType = null)
+            string identitySuffix, Type dataType, ExplicitRegistrationType? explicitRegistrationType = null)
             => new StatBuilder(StatFactory,
                 CoreStatBuilderFromIdentity(identitySuffix, dataType, explicitRegistrationType));
 
@@ -61,7 +61,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Effects
             DamageRelatedStatBuilder.Create(StatFactory, CoreStatBuilderFromIdentity(identitySuffix, dataType));
 
         protected ICoreStatBuilder CoreStatBuilderFromIdentity(
-            string identitySuffix, Type dataType, ExplicitRegistrationType explicitRegistrationType = null)
+            string identitySuffix, Type dataType, ExplicitRegistrationType? explicitRegistrationType = null)
             => new CoreStatBuilderFromCoreBuilder<string>(Identity,
                 (e, id) => StatFactory.FromIdentity(id + "." + identitySuffix, e, dataType, explicitRegistrationType));
 

--- a/PoESkillTree.Engine.Computation.Builders/ICoreBuilder.cs
+++ b/PoESkillTree.Engine.Computation.Builders/ICoreBuilder.cs
@@ -20,7 +20,7 @@ namespace PoESkillTree.Engine.Computation.Builders
 
         public static ICoreBuilder<TResult>
             Create<TParameter, TResult>(TParameter parameter, Func<BuildParameters, TParameter, TResult> build)
-            where TParameter : IResolvable<TParameter>
+            where TParameter : class, IResolvable<TParameter>
         {
             return new ParametrisedCoreBuilder<TParameter, TResult>(parameter, build);
         }
@@ -38,14 +38,15 @@ namespace PoESkillTree.Engine.Computation.Builders
 
         public static ICoreBuilder<TResult> Proxy<TProxied, TResult>(
             TProxied proxiedBuilder, Func<BuildParameters, TProxied, TResult> build)
-            where TProxied : IResolvable<TProxied>
+            where TProxied : class, IResolvable<TProxied>
         {
             return new ProxyCoreBuilder<TProxied, TResult>(proxiedBuilder, build);
         }
 
         public static ICoreBuilder<TResult> Proxy<TProxied, TResolve, TResult>(
             TProxied proxiedBuilder, Func<BuildParameters, TProxied, TResult> build)
-            where TProxied : IResolvable<TResolve>, TResolve
+            where TProxied : class, IResolvable<TResolve>, TResolve
+            where TResolve : class
         {
             return new ProxyCoreBuilder<TProxied, TResolve, TResult>(proxiedBuilder, build);
         }
@@ -74,7 +75,7 @@ namespace PoESkillTree.Engine.Computation.Builders
     }
 
     internal class ParametrisedCoreBuilder<TParameter, TResult> : ICoreBuilder<TResult>
-        where TParameter : IResolvable<TParameter>
+        where TParameter : class, IResolvable<TParameter>
     {
         private readonly TParameter _parameter;
         private readonly Func<BuildParameters, TParameter, TResult> _build;
@@ -131,7 +132,7 @@ namespace PoESkillTree.Engine.Computation.Builders
     }
 
     internal class ProxyCoreBuilder<TProxied, TResult> : ICoreBuilder<TResult>
-        where TProxied : IResolvable<TProxied>
+        where TProxied : class, IResolvable<TProxied>
     {
         private readonly TProxied _proxiedBuilder;
         private readonly Func<BuildParameters, TProxied, TResult> _build;
@@ -149,7 +150,8 @@ namespace PoESkillTree.Engine.Computation.Builders
     }
 
     internal class ProxyCoreBuilder<TProxied, TResolve, TResult> : ICoreBuilder<TResult>
-        where TProxied : IResolvable<TResolve>, TResolve
+        where TProxied : class, IResolvable<TResolve>, TResolve
+        where TResolve : class
     {
         private readonly TProxied _proxiedBuilder;
         private readonly Func<BuildParameters, TProxied, TResult> _build;

--- a/PoESkillTree.Engine.Computation.Builders/PoESkillTree.Engine.Computation.Builders.csproj
+++ b/PoESkillTree.Engine.Computation.Builders/PoESkillTree.Engine.Computation.Builders.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Version>1.0.0</Version>
     <FileVersion>1.0.0.0</FileVersion>

--- a/PoESkillTree.Engine.Computation.Builders/PoESkillTree.Engine.Computation.Builders.csproj
+++ b/PoESkillTree.Engine.Computation.Builders/PoESkillTree.Engine.Computation.Builders.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8</LangVersion>
     <Version>1.0.0</Version>
     <FileVersion>1.0.0.0</FileVersion>
 
@@ -17,6 +17,11 @@
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSources>true</IncludeSources>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <WarningsAsErrors>8600;8601;8602;8603;8604;8613;8619;8620;8625</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Enums.NET" Version="2.3.2" />

--- a/PoESkillTree.Engine.Computation.Builders/PoESkillTree.Engine.Computation.Builders.csproj
+++ b/PoESkillTree.Engine.Computation.Builders/PoESkillTree.Engine.Computation.Builders.csproj
@@ -27,6 +27,10 @@
     <PackageReference Include="Enums.NET" Version="2.3.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All" />
     <PackageReference Include="morelinq" Version="3.2.0" />
+    <PackageReference Include="Nullable" Version="1.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PoESkillTree.Engine.Utils\PoESkillTree.Engine.Utils.csproj" />

--- a/PoESkillTree.Engine.Computation.Builders/Resolving/UnresolvedBuilder.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Resolving/UnresolvedBuilder.cs
@@ -15,6 +15,7 @@ using PoESkillTree.Engine.Utils;
 namespace PoESkillTree.Engine.Computation.Builders.Resolving
 {
     public class UnresolvedBuilder<TResolve, TBuild> : IResolvable<TResolve>
+        where TResolve : class
     {
         protected string Description { get; }
         protected Func<ResolveContext, TResolve> Resolver { get; }

--- a/PoESkillTree.Engine.Computation.Builders/Skills/SkillBuilder.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Skills/SkillBuilder.cs
@@ -41,7 +41,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Skills
 
         public IStatBuilder ReservationPool => CreateStatBuilder(typeof(Pool));
 
-        private IStatBuilder CreateStatBuilder(Type dataType, [CallerMemberName] string identitySuffix = null)
+        private IStatBuilder CreateStatBuilder(Type dataType, [CallerMemberName] string identitySuffix = "")
             => new StatBuilder(_statFactory, new CoreStatBuilderFromCoreBuilder<SkillDefinition>(_coreBuilder,
                 (e, d) => _statFactory.FromIdentity($"{d.Id}.{identitySuffix}", e, dataType)));
 

--- a/PoESkillTree.Engine.Computation.Builders/Skills/SkillBuilderCollection.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Skills/SkillBuilderCollection.cs
@@ -62,7 +62,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Skills
 
         private IEnumerable<IStat> SelectSkillStats(
             IEnumerable<Keyword> keywords, Entity entity, Type dataType,
-            [CallerMemberName] string identitySuffix = null)
+            [CallerMemberName] string identitySuffix = "")
         {
             var keywordList = keywords.ToList();
             return from skill in _skills

--- a/PoESkillTree.Engine.Computation.Builders/Skills/SkillBuilders.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Skills/SkillBuilders.cs
@@ -38,7 +38,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Skills
 
         private SkillDefinition BuildModifierSourceSkill(BuildParameters parameters)
         {
-            var modifierSource = parameters.ModifierSource;
+            ModifierSource? modifierSource = parameters.ModifierSource;
             if (modifierSource is ModifierSource.Global global)
                 modifierSource = global.LocalSource;
 

--- a/PoESkillTree.Engine.Computation.Builders/Stats/ConversionStatBuilder.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Stats/ConversionStatBuilder.cs
@@ -1,13 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using MoreLinq;
 using PoESkillTree.Engine.Computation.Common;
 using PoESkillTree.Engine.Computation.Common.Builders;
 using PoESkillTree.Engine.Computation.Common.Builders.Entities;
 using PoESkillTree.Engine.Computation.Common.Builders.Resolving;
 using PoESkillTree.Engine.Computation.Common.Builders.Stats;
 using PoESkillTree.Engine.Computation.Common.Parsing;
+#if NETSTANDARD2_0
+using static MoreLinq.Extensions.ToHashSetExtension;
+#endif
 
 namespace PoESkillTree.Engine.Computation.Builders.Stats
 {

--- a/PoESkillTree.Engine.Computation.Builders/Stats/CoreStatBuilderFromCoreBuilder.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Stats/CoreStatBuilderFromCoreBuilder.cs
@@ -21,14 +21,14 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
         private readonly IEntityBuilder _entityBuilder;
 
         public CoreStatBuilderFromCoreBuilder(
-            ICoreBuilder<T> coreBuilder, Func<Entity, T, IStat> statFactory, IEntityBuilder entityBuilder = null)
+            ICoreBuilder<T> coreBuilder, Func<Entity, T, IStat> statFactory, IEntityBuilder? entityBuilder = null)
             : this(coreBuilder, (ps, e, t) => new[] { statFactory(e, t) }, entityBuilder)
         {
         }
 
         public CoreStatBuilderFromCoreBuilder(
             ICoreBuilder<T> coreBuilder, Func<BuildParameters, Entity, T, IStat> statFactory,
-            IEntityBuilder entityBuilder = null)
+            IEntityBuilder? entityBuilder = null)
             : this(coreBuilder, (ps, e, t) => new[] { statFactory(ps, e, t) }, entityBuilder)
         {
         }
@@ -36,7 +36,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
         public CoreStatBuilderFromCoreBuilder(
             ICoreBuilder<T> coreBuilder,
             StatFactory statFactory,
-            IEntityBuilder entityBuilder = null)
+            IEntityBuilder? entityBuilder = null)
         {
             _coreBuilder = coreBuilder;
             _statFactory = statFactory;

--- a/PoESkillTree.Engine.Computation.Builders/Stats/DamageSpecificationBuilder.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Stats/DamageSpecificationBuilder.cs
@@ -27,7 +27,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
         private readonly Mode _mode;
         private readonly DamageSource? _damageSource;
         private readonly AttackDamageHand? _hand;
-        private readonly IAilmentBuilder _ailment;
+        private readonly IAilmentBuilder? _ailment;
 
         public DamageSpecificationBuilder()
             : this(Mode.Skills | Mode.Ailments, null, null, null)
@@ -35,7 +35,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
         }
 
         private DamageSpecificationBuilder(
-            Mode mode, DamageSource? damageSource, IAilmentBuilder ailment, AttackDamageHand? hand)
+            Mode mode, DamageSource? damageSource, IAilmentBuilder? ailment, AttackDamageHand? hand)
         {
             _mode = mode;
             _damageSource = damageSource;
@@ -46,7 +46,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
         public DamageSpecificationBuilder Resolve(ResolveContext context)
         {
             return new DamageSpecificationBuilder(_mode, _damageSource,
-                (IAilmentBuilder) _ailment?.Resolve(context), _hand);
+                (IAilmentBuilder?) _ailment?.Resolve(context), _hand);
         }
 
         public DamageSpecificationBuilder With(DamageSource damageSource)

--- a/PoESkillTree.Engine.Computation.Builders/Stats/DamageStatConcretizer.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Stats/DamageStatConcretizer.cs
@@ -55,7 +55,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
 
         private DamageStatConcretizer WithCanApply(DamageSpecificationBuilder specificationBuilder,
             bool applyToSkillDamage = false, bool applyToAilmentDamage = false,
-            Func<IDamageSpecification, IConditionBuilder> condition = null)
+            Func<IDamageSpecification, IConditionBuilder>? condition = null)
         {
             return new DamageStatConcretizer(_statFactory, specificationBuilder,
                 CanApplyToSkillDamage && applyToSkillDamage ? true : _applyToSkillDamage,

--- a/PoESkillTree.Engine.Computation.Builders/Stats/EvasionStatBuilder.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Stats/EvasionStatBuilder.cs
@@ -19,7 +19,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
 
         public IStatBuilder ChanceAgainstMeleeAttacks => FromIdentity(typeof(uint));
 
-        private IStatBuilder FromIdentity(Type dataType, [CallerMemberName] string identity = null)
+        private IStatBuilder FromIdentity(Type dataType, [CallerMemberName] string identity = "")
             => With(LeafCoreStatBuilder.FromIdentity(StatFactory, Prefix + "." + identity, dataType));
     }
 }

--- a/PoESkillTree.Engine.Computation.Builders/Stats/IStatFactory.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Stats/IStatFactory.cs
@@ -13,10 +13,10 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
     public interface IStatFactory
     {
         IStat FromIdentity(string identity, Entity entity, Type dataType,
-            ExplicitRegistrationType explicitRegistrationType = null);
+            ExplicitRegistrationType? explicitRegistrationType = null);
 
         IStat CopyWithSuffix(IStat stat, string identitySuffix, Type dataType,
-            ExplicitRegistrationType explicitRegistrationType = null);
+            ExplicitRegistrationType? explicitRegistrationType = null);
 
         IStat ChanceToDouble(IStat stat);
 

--- a/PoESkillTree.Engine.Computation.Builders/Stats/LeafCoreStatBuilder.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Stats/LeafCoreStatBuilder.cs
@@ -17,7 +17,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
         private readonly Func<Entity, IStat> _statFactory;
         private readonly IEntityBuilder _entityBuilder;
 
-        public LeafCoreStatBuilder(Func<Entity, IStat> statFactory, IEntityBuilder entityBuilder = null)
+        public LeafCoreStatBuilder(Func<Entity, IStat> statFactory, IEntityBuilder? entityBuilder = null)
         {
             _statFactory = statFactory;
             _entityBuilder = entityBuilder ?? new ModifierSourceEntityBuilder();
@@ -25,7 +25,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
 
         public static ICoreStatBuilder FromIdentity(
             IStatFactory statFactory, string identity, Type dataType,
-            ExplicitRegistrationType explicitRegistrationType = null) =>
+            ExplicitRegistrationType? explicitRegistrationType = null) =>
             new LeafCoreStatBuilder(
                 entity => statFactory.FromIdentity(identity, entity, dataType, explicitRegistrationType));
 

--- a/PoESkillTree.Engine.Computation.Builders/Stats/ParametrisedCoreStatBuilder.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Stats/ParametrisedCoreStatBuilder.cs
@@ -10,7 +10,7 @@ using PoESkillTree.Engine.Computation.Common.Builders.Stats;
 namespace PoESkillTree.Engine.Computation.Builders.Stats
 {
     internal class ParametrisedCoreStatBuilder<TParameter> : ICoreStatBuilder
-        where TParameter : IResolvable<TParameter>
+        where TParameter : class, IResolvable<TParameter>
     {
         private readonly ICoreStatBuilder _inner;
         private readonly TParameter _parameter;

--- a/PoESkillTree.Engine.Computation.Builders/Stats/PassiveTreeBuilders.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Stats/PassiveTreeBuilders.cs
@@ -106,7 +106,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
 
         private static ModifierSource.Local.Jewel GetJewelSource(BuildParameters parameters)
         {
-            var modifierSource = parameters.ModifierSource;
+            ModifierSource? modifierSource = parameters.ModifierSource;
             if (modifierSource is ModifierSource.Global globalSource)
                 modifierSource = globalSource.LocalSource;
             if (modifierSource is ModifierSource.Local.Jewel jewelSource)

--- a/PoESkillTree.Engine.Computation.Builders/Stats/PoolStatBuilder.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Stats/PoolStatBuilder.cs
@@ -160,18 +160,18 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
         protected abstract IStatBuilder Create(ICoreStatBuilder coreStatBuilder, ICoreBuilder<Pool> pool);
 
         protected IStatBuilder FromIdentity(
-            Type dataType, ExplicitRegistrationType explicitRegistrationType = null,
-            [CallerMemberName] string identitySuffix = null)
+            Type dataType, ExplicitRegistrationType? explicitRegistrationType = null,
+            [CallerMemberName] string identitySuffix = "")
             => new StatBuilder(StatFactory, CreateCoreStatBuilder(identitySuffix, dataType, explicitRegistrationType));
 
         protected IDamageRelatedStatBuilder DamageRelatedFromIdentity(
-            Type dataType, ExplicitRegistrationType explicitRegistrationType = null,
-            [CallerMemberName] string identitySuffix = null)
+            Type dataType, ExplicitRegistrationType? explicitRegistrationType = null,
+            [CallerMemberName] string identitySuffix = "")
             => DamageRelatedStatBuilder.Create(StatFactory,
                 CreateCoreStatBuilder(identitySuffix, dataType, explicitRegistrationType));
 
         private ICoreStatBuilder CreateCoreStatBuilder(
-            string identitySuffix, Type dataType, ExplicitRegistrationType explicitRegistrationType)
+            string identitySuffix, Type dataType, ExplicitRegistrationType? explicitRegistrationType)
             => new CoreStatBuilderFromCoreBuilder<Pool>(Pool,
                 (e, p) => StatFactory.FromIdentity($"{p}{_identitySuffix}.{identitySuffix}", e, dataType,
                     explicitRegistrationType));

--- a/PoESkillTree.Engine.Computation.Builders/Stats/Stat.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Stats/Stat.cs
@@ -14,8 +14,8 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
             typeof(double), typeof(int), typeof(uint)
         };
 
-        public Stat(string identity, Entity entity = default, Type dataType = null,
-            ExplicitRegistrationType explicitRegistrationType = null, IReadOnlyList<Behavior> behaviors = null)
+        public Stat(string identity, Entity entity = default, Type? dataType = null,
+            ExplicitRegistrationType? explicitRegistrationType = null, IReadOnlyList<Behavior>? behaviors = null)
         {
             if (!IsDataTypeValid(dataType))
                 throw new ArgumentException($"Stats only support double, int, bool or enum data types, {dataType} given",
@@ -29,25 +29,25 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
             Behaviors = behaviors ?? new Behavior[0];
         }
 
-        private static bool IsDataTypeValid(Type dataType)
+        private static bool IsDataTypeValid(Type? dataType)
             => dataType == null || dataType == typeof(bool) || NumericTypes.Contains(dataType) || dataType.IsEnum;
 
         private readonly bool _hasRange;
         public string Identity { get; }
         public Entity Entity { get; }
-        public ExplicitRegistrationType ExplicitRegistrationType { get; }
+        public ExplicitRegistrationType? ExplicitRegistrationType { get; }
         public Type DataType { get; }
         public IReadOnlyList<Behavior> Behaviors { get; }
 
-        public IStat Minimum => MinOrMax();
-        public IStat Maximum => MinOrMax();
+        public IStat? Minimum => MinOrMax();
+        public IStat? Maximum => MinOrMax();
 
-        private IStat MinOrMax([CallerMemberName] string identitySuffix = null) =>
+        private IStat? MinOrMax([CallerMemberName] string identitySuffix = "") =>
             _hasRange ? new Stat(Identity + "." + identitySuffix, Entity, DataType) : null;
 
-        private string _stringRepresentation;
+        private string? _stringRepresentation;
         public override string ToString()
-            => _stringRepresentation ?? (_stringRepresentation = Entity.GetName() + "." + Identity);
+            => _stringRepresentation ??= Entity.GetName() + "." + Identity;
 
         public override bool Equals(object obj) =>
             (obj == this) || (obj is IStat other && Equals(other));

--- a/PoESkillTree.Engine.Computation.Builders/Stats/StatBuilderAdapter.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Stats/StatBuilderAdapter.cs
@@ -15,16 +15,16 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
     public class StatBuilderAdapter : ICoreStatBuilder
     {
         private readonly IStatBuilder _statBuilder;
-        private readonly IConditionBuilder _conditionBuilder;
+        private readonly IConditionBuilder? _conditionBuilder;
         private readonly Func<IStat, IStat> _statConverter;
 
-        public StatBuilderAdapter(IStatBuilder statBuilder, IConditionBuilder conditionBuilder = null)
+        public StatBuilderAdapter(IStatBuilder statBuilder, IConditionBuilder? conditionBuilder = null)
             : this(statBuilder, conditionBuilder, Funcs.Identity)
         {
         }
 
         private StatBuilderAdapter(
-            IStatBuilder statBuilder, IConditionBuilder conditionBuilder, Func<IStat, IStat> statConverter)
+            IStatBuilder statBuilder, IConditionBuilder? conditionBuilder, Func<IStat, IStat> statConverter)
         {
             _statBuilder = statBuilder;
             _conditionBuilder = conditionBuilder;

--- a/PoESkillTree.Engine.Computation.Builders/Stats/StatBuilderUtils.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Stats/StatBuilderUtils.cs
@@ -9,12 +9,12 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
     {
         public static IConditionBuilder ConditionFromIdentity(
             IStatFactory statFactory, string identity,
-            ExplicitRegistrationType explicitRegistrationType = null) =>
+            ExplicitRegistrationType? explicitRegistrationType = null) =>
             FromIdentity(statFactory, identity, typeof(bool), explicitRegistrationType).IsSet;
 
         public static IStatBuilder FromIdentity(
             IStatFactory statFactory, string identity, Type dataType,
-            ExplicitRegistrationType explicitRegistrationType = null) =>
+            ExplicitRegistrationType? explicitRegistrationType = null) =>
             new StatBuilder(statFactory,
                 LeafCoreStatBuilder.FromIdentity(statFactory, identity, dataType, explicitRegistrationType));
 

--- a/PoESkillTree.Engine.Computation.Builders/Stats/StatBuilders.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Stats/StatBuilders.cs
@@ -163,7 +163,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
         public IStatBuilder Dexterity => Requirement();
         public IStatBuilder Intelligence => Requirement();
 
-        private IStatBuilder Requirement([CallerMemberName] string requiredStat = null)
+        private IStatBuilder Requirement([CallerMemberName] string requiredStat = "")
             => FromStatFactory(e => StatFactory.Requirement(StatFactory.FromIdentity(requiredStat, e, typeof(uint))));
     }
 

--- a/PoESkillTree.Engine.Computation.Builders/Stats/StatBuildersBase.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Stats/StatBuildersBase.cs
@@ -14,20 +14,20 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
             StatFactory = statFactory;
 
         protected IStatBuilder FromIdentity(
-            Type dataType, ExplicitRegistrationType explicitRegistrationType = null,
-            [CallerMemberName] string identity = null) =>
+            Type dataType, ExplicitRegistrationType? explicitRegistrationType = null,
+            [CallerMemberName] string identity = "") =>
             FromIdentity(identity, dataType, explicitRegistrationType);
 
         protected virtual IStatBuilder FromIdentity(
             string identity, Type dataType,
-            ExplicitRegistrationType explicitRegistrationType = null) =>
+            ExplicitRegistrationType? explicitRegistrationType = null) =>
             StatBuilderUtils.FromIdentity(StatFactory, identity, dataType, explicitRegistrationType);
 
         protected IStatBuilder FromStatFactory(Func<Entity, IStat> statFactory)
             => new StatBuilder(StatFactory, new LeafCoreStatBuilder(statFactory));
 
         protected IDamageRelatedStatBuilder DamageRelatedFromIdentity(
-            Type dataType, [CallerMemberName] string identity = null) =>
+            Type dataType, [CallerMemberName] string identity = "") =>
             DamageRelatedFromIdentity(identity, dataType);
 
         protected virtual IDamageRelatedStatBuilder DamageRelatedFromIdentity(string identity, Type dataType) =>
@@ -42,7 +42,7 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
             => _identityPrefix = identityPrefix;
 
         protected override IStatBuilder FromIdentity(
-            string identity, Type dataType, ExplicitRegistrationType explicitRegistrationType = null)
+            string identity, Type dataType, ExplicitRegistrationType? explicitRegistrationType = null)
             => base.FromIdentity(_identityPrefix + "." + identity, dataType, explicitRegistrationType);
 
         protected override IDamageRelatedStatBuilder DamageRelatedFromIdentity(string identity, Type dataType)

--- a/PoESkillTree.Engine.Computation.Builders/Stats/StatFactory.cs
+++ b/PoESkillTree.Engine.Computation.Builders/Stats/StatFactory.cs
@@ -26,11 +26,11 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
         }
 
         public IStat FromIdentity(string identity, Entity entity, Type dataType,
-            ExplicitRegistrationType explicitRegistrationType = null) =>
+            ExplicitRegistrationType? explicitRegistrationType = null) =>
             GetOrAdd(identity, entity, dataType, explicitRegistrationType);
 
         public IStat CopyWithSuffix(IStat stat, string identitySuffix, Type dataType,
-            ExplicitRegistrationType explicitRegistrationType = null) =>
+            ExplicitRegistrationType? explicitRegistrationType = null) =>
             CopyWithSuffix(stat, identitySuffix, dataType, null, explicitRegistrationType);
 
         public IStat ChanceToDouble(IStat stat) =>
@@ -153,14 +153,14 @@ namespace PoESkillTree.Engine.Computation.Builders.Stats
                 behaviors: () => _behaviorFactory.ItemProperty(stat, slot));
 
         private IStat CopyWithSuffix(IStat source, string identitySuffix, Type dataType,
-            Func<IReadOnlyList<Behavior>> behaviors, ExplicitRegistrationType explicitRegistrationType = null)
+            Func<IReadOnlyList<Behavior>>? behaviors, ExplicitRegistrationType? explicitRegistrationType = null)
         {
             return GetOrAdd(source.Identity + "." + identitySuffix, source.Entity,
                 dataType, explicitRegistrationType, behaviors);
         }
 
         private IStat GetOrAdd(string identity, Entity entity, Type dataType,
-            ExplicitRegistrationType explicitRegistrationType = null, Func<IReadOnlyList<Behavior>> behaviors = null)
+            ExplicitRegistrationType? explicitRegistrationType = null, Func<IReadOnlyList<Behavior>>? behaviors = null)
         {
             // Func<IReadOnlyList<Behavior>> for performance reasons: Only retrieve behaviors if necessary.
             return _cache.GetOrAdd((identity, entity), _ =>

--- a/PoESkillTree.Engine.Computation.Common.Tests/Builders/Modifiers/IntermediateModifierExtensionsTest.cs
+++ b/PoESkillTree.Engine.Computation.Common.Tests/Builders/Modifiers/IntermediateModifierExtensionsTest.cs
@@ -351,8 +351,8 @@ namespace PoESkillTree.Engine.Computation.Common.Builders.Modifiers
             => new[] { CreateFilledEntry(), CreateFilledEntry(), CreateFilledEntry() };
 
         private static IntermediateModifierEntry CreateFilledEntry(
-            IFormBuilder form = null, IStatBuilder stat = null, IValueBuilder value = null,
-            IConditionBuilder condition = null)
+            IFormBuilder? form = null, IStatBuilder? stat = null, IValueBuilder? value = null,
+            IConditionBuilder? condition = null)
             => new IntermediateModifierEntry(
                 form ?? Mock.Of<IFormBuilder>(),
                 stat ?? Mock.Of<IStatBuilder>(),
@@ -378,9 +378,9 @@ namespace PoESkillTree.Engine.Computation.Common.Builders.Modifiers
             return CreateResult(entries, null);
         }
 
-        private static IIntermediateModifier CreateResult(IReadOnlyList<IntermediateModifierEntry> entries = null,
-            StatConverter statConverter = null,
-            ValueConverter valueConverter = null)
+        private static IIntermediateModifier CreateResult(IReadOnlyList<IntermediateModifierEntry>? entries = null,
+            StatConverter? statConverter = null,
+            ValueConverter? valueConverter = null)
         {
             return new SimpleIntermediateModifier(entries ?? new IntermediateModifierEntry[0],
                 statConverter ?? (s => s),

--- a/PoESkillTree.Engine.Computation.Common.Tests/Builders/Modifiers/IntermediateModifierResolverTest.cs
+++ b/PoESkillTree.Engine.Computation.Common.Tests/Builders/Modifiers/IntermediateModifierResolverTest.cs
@@ -63,7 +63,7 @@ namespace PoESkillTree.Engine.Computation.Common.Builders.Modifiers
         }
 
         private static readonly
-            (Func<IReadOnlyList<object>> expectedSelector, Func<IntermediateModifierEntry, object> actualSelector)[]
+            (Func<IReadOnlyList<object>> expectedSelector, Func<IntermediateModifierEntry, object?> actualSelector)[]
             ResolveReturnsCorrectEntryElementsCases =
             {
                 (() => DefaultValues, e => e.Value),
@@ -71,6 +71,7 @@ namespace PoESkillTree.Engine.Computation.Common.Builders.Modifiers
                 (() => DefaultStats, e => e.Stat),
                 (() => DefaultConditions, e => e.Condition),
             };
+
         [TestCase(0, TestName = "ResolveReturnsCorrectValues")]
         [TestCase(1, TestName = "ResolveReturnsCorrectForms")]
         [TestCase(2, TestName = "ResolveReturnsCorrectStats")]
@@ -180,7 +181,7 @@ namespace PoESkillTree.Engine.Computation.Common.Builders.Modifiers
         {
             var entry = new IntermediateModifierEntry()
                 .WithStat(DefaultStats[0]);
-            StatConverter statConverter = s => s == DefaultStats[0] ? DefaultStats[1] : null;
+            StatConverter statConverter = s => s == DefaultStats[0] ? DefaultStats[1] : s;
             var result = Mock.Of<IIntermediateModifier>(r =>
                 r.Entries == new[] { entry } &&
                 r.ValueConverter == Funcs.Identity &&

--- a/PoESkillTree.Engine.Computation.Common.Tests/Builders/Modifiers/ModifierBuilderTest.cs
+++ b/PoESkillTree.Engine.Computation.Common.Tests/Builders/Modifiers/ModifierBuilderTest.cs
@@ -281,7 +281,7 @@ namespace PoESkillTree.Engine.Computation.Common.Builders.Modifiers
         public void WithStatConverterSetsStatConverter()
         {
             var sut = ModifierBuilder.Empty;
-            StatConverter statConverter = s => null;
+            StatConverter statConverter = s => null!;
 
             sut = (ModifierBuilder) sut.WithStatConverter(statConverter);
 
@@ -292,7 +292,7 @@ namespace PoESkillTree.Engine.Computation.Common.Builders.Modifiers
         public void WithValueConverterSetsValueConverter()
         {
             var sut = ModifierBuilder.Empty;
-            ValueConverter valueConverter = v => null;
+            ValueConverter valueConverter = v => null!;
 
             sut = (ModifierBuilder) sut.WithValueConverter(valueConverter);
 

--- a/PoESkillTree.Engine.Computation.Common.Tests/Builders/Values/ValueBuilderStub.cs
+++ b/PoESkillTree.Engine.Computation.Common.Tests/Builders/Values/ValueBuilderStub.cs
@@ -18,7 +18,7 @@ namespace PoESkillTree.Engine.Computation.Common.Builders.Values
             if (value is ValueBuilder b)
             {
                 // Easiest way to get the underlying value back.
-                value = b.Resolve(null);
+                value = b.Resolve(null!);
             }
             return ((ValueBuilderStub) value).Value;
         }

--- a/PoESkillTree.Engine.Computation.Common.Tests/Helper.cs
+++ b/PoESkillTree.Engine.Computation.Common.Tests/Helper.cs
@@ -13,11 +13,11 @@ namespace PoESkillTree.Engine.Computation.Common
             Enumerable.Range(0, count).Select(_ => MockModifier()).ToArray();
 
         public static Modifier MockModifier(
-            IStat stat, Form form = Form.BaseAdd, IValue value = null, ModifierSource source = null) =>
+            IStat stat, Form form = Form.BaseAdd, IValue? value = null, ModifierSource? source = null) =>
             MockModifier(new[] { stat }, form, value, source);
 
         public static Modifier MockModifier(
-            IReadOnlyList<IStat> stats = null, Form form = Form.BaseAdd, IValue value = null, ModifierSource source = null) => 
+            IReadOnlyList<IStat>? stats = null, Form form = Form.BaseAdd, IValue? value = null, ModifierSource? source = null) => 
             new Modifier(stats ?? new IStat[0], form, value ?? Mock.Of<IValue>(), source ?? new ModifierSource.Global());
     }
 }

--- a/PoESkillTree.Engine.Computation.Common.Tests/PoESkillTree.Engine.Computation.Common.Tests.csproj
+++ b/PoESkillTree.Engine.Computation.Common.Tests/PoESkillTree.Engine.Computation.Common.Tests.csproj
@@ -2,11 +2,13 @@
   <PropertyGroup>
     <RootNamespace>PoESkillTree.Engine.Computation.Common</RootNamespace>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8</LangVersion>
     <AssemblyTitle>PoESkillTree.Engine.Computation.Common.Tests</AssemblyTitle>
     <Product>PoESkillTree.Engine.Computation.Common.Tests</Product>
     <Copyright>Copyright ©  2018</Copyright>
     <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>8600;8601;8602;8603;8604;8619;8620</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/PoESkillTree.Engine.Computation.Common.Tests/PoESkillTree.Engine.Computation.Common.Tests.csproj
+++ b/PoESkillTree.Engine.Computation.Common.Tests/PoESkillTree.Engine.Computation.Common.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>PoESkillTree.Engine.Computation.Common</RootNamespace>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyTitle>PoESkillTree.Engine.Computation.Common.Tests</AssemblyTitle>
     <Product>PoESkillTree.Engine.Computation.Common.Tests</Product>

--- a/PoESkillTree.Engine.Computation.Common.Tests/PoESkillTree.Engine.Computation.Common.Tests.csproj
+++ b/PoESkillTree.Engine.Computation.Common.Tests/PoESkillTree.Engine.Computation.Common.Tests.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.12.0" />
+    <PackageReference Include="Moq" Version="4.13.0" />
     <PackageReference Include="morelinq" Version="3.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PoESkillTree.Engine.GameModel\PoESkillTree.Engine.GameModel.csproj" />

--- a/PoESkillTree.Engine.Computation.Common.Tests/StatStub.cs
+++ b/PoESkillTree.Engine.Computation.Common.Tests/StatStub.cs
@@ -12,7 +12,7 @@ namespace PoESkillTree.Engine.Computation.Common
 
         private readonly int _instance;
 
-        public StatStub(IStat minimum = null, IStat maximum = null)
+        public StatStub(IStat? minimum = null, IStat? maximum = null)
         {
             _instance = _instanceCounter++;
             Minimum = minimum;
@@ -21,11 +21,11 @@ namespace PoESkillTree.Engine.Computation.Common
 
         public bool Equals(IStat other) => Equals((object) other);
 
-        public IStat Minimum { get; }
-        public IStat Maximum { get; }
+        public IStat? Minimum { get; }
+        public IStat? Maximum { get; }
         public string Identity => _instance.ToString();
         public Entity Entity => Entity.Character;
-        public ExplicitRegistrationType ExplicitRegistrationType { get; set; }
+        public ExplicitRegistrationType? ExplicitRegistrationType { get; set; }
         public Type DataType => typeof(double);
         public IReadOnlyList<Behavior> Behaviors => new Behavior[0];
     }

--- a/PoESkillTree.Engine.Computation.Common/Builders/Buffs/IBuffBuilders.cs
+++ b/PoESkillTree.Engine.Computation.Common/Builders/Buffs/IBuffBuilders.cs
@@ -101,7 +101,7 @@ namespace PoESkillTree.Engine.Computation.Common.Builders.Buffs
         /// <para>If no source and/or target is given, it defaults to any entity, e.g. Buffs() without parameters
         /// returns every active buff.</para>
         /// </summary>
-        IBuffBuilderCollection Buffs(IEntityBuilder source = null, params IEntityBuilder[] targets);
+        IBuffBuilderCollection Buffs(IEntityBuilder? source = null, params IEntityBuilder[] targets);
 
         IStatBuilder CurseLimit { get; }
     }

--- a/PoESkillTree.Engine.Computation.Common/Builders/Conditions/ConditionBuilderResult.cs
+++ b/PoESkillTree.Engine.Computation.Common/Builders/Conditions/ConditionBuilderResult.cs
@@ -14,7 +14,7 @@ namespace PoESkillTree.Engine.Computation.Common.Builders.Conditions
         {
         }
 
-        public ConditionBuilderResult(StatConverter statConverter = null, IValue value = null)
+        public ConditionBuilderResult(StatConverter? statConverter = null, IValue? value = null)
         {
             HasStatConverter = !(statConverter is null);
             StatConverter = statConverter ?? Funcs.Identity;

--- a/PoESkillTree.Engine.Computation.Common/Builders/Modifiers/IModifierBuilder.cs
+++ b/PoESkillTree.Engine.Computation.Common/Builders/Modifiers/IModifierBuilder.cs
@@ -24,23 +24,23 @@ namespace PoESkillTree.Engine.Computation.Common.Builders.Modifiers
     {
         IModifierBuilder WithForm(IFormBuilder form);
 
-        IModifierBuilder WithForms(IReadOnlyList<IFormBuilder> forms);
+        IModifierBuilder WithForms(IReadOnlyList<IFormBuilder?> forms);
 
         IModifierBuilder WithStat(IStatBuilder stat);
 
-        IModifierBuilder WithStats(IReadOnlyList<IStatBuilder> stats);
+        IModifierBuilder WithStats(IReadOnlyList<IStatBuilder?> stats);
 
         IModifierBuilder WithStatConverter(StatConverter converter);
 
         IModifierBuilder WithValue(IValueBuilder value);
 
-        IModifierBuilder WithValues(IReadOnlyList<IValueBuilder> values);
+        IModifierBuilder WithValues(IReadOnlyList<IValueBuilder?> values);
 
         IModifierBuilder WithValueConverter(ValueConverter converter);
 
         IModifierBuilder WithCondition(IConditionBuilder condition);
 
-        IModifierBuilder WithConditions(IReadOnlyList<IConditionBuilder> conditions);
+        IModifierBuilder WithConditions(IReadOnlyList<IConditionBuilder?> conditions);
 
         /// <summary>
         /// Builds this instance to an <see cref="IIntermediateModifier"/>.

--- a/PoESkillTree.Engine.Computation.Common/Builders/Modifiers/IntermediateModifierEntry.cs
+++ b/PoESkillTree.Engine.Computation.Common/Builders/Modifiers/IntermediateModifierEntry.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using JetBrains.Annotations;
 using PoESkillTree.Engine.Computation.Common.Builders.Conditions;
 using PoESkillTree.Engine.Computation.Common.Builders.Forms;
 using PoESkillTree.Engine.Computation.Common.Builders.Stats;
@@ -15,24 +14,20 @@ namespace PoESkillTree.Engine.Computation.Common.Builders.Modifiers
     /// </summary>
     public class IntermediateModifierEntry : ValueObject
     {
-        [CanBeNull]
-        public IFormBuilder Form { get; }
+        public IFormBuilder? Form { get; }
 
-        [CanBeNull]
-        public IStatBuilder Stat { get; }
+        public IStatBuilder? Stat { get; }
 
-        [CanBeNull]
-        public IValueBuilder Value { get; }
+        public IValueBuilder? Value { get; }
 
-        [CanBeNull]
-        public IConditionBuilder Condition { get; }
+        public IConditionBuilder? Condition { get; }
 
         public IntermediateModifierEntry()
         {
         }
 
         public IntermediateModifierEntry(
-            IFormBuilder form, IStatBuilder stat, IValueBuilder value, IConditionBuilder condition)
+            IFormBuilder? form, IStatBuilder? stat, IValueBuilder? value, IConditionBuilder? condition)
         {
             Form = form;
             Stat = stat;
@@ -40,28 +35,28 @@ namespace PoESkillTree.Engine.Computation.Common.Builders.Modifiers
             Condition = condition;
         }
 
-        public IntermediateModifierEntry WithForm(IFormBuilder form)
+        public IntermediateModifierEntry WithForm(IFormBuilder? form)
         {
             if (Form != null && form != null)
                 throw new InvalidOperationException(nameof(WithForm) + " must not be called multiple times");
             return new IntermediateModifierEntry(form, Stat, Value, Condition);
         }
 
-        public IntermediateModifierEntry WithStat(IStatBuilder stat)
+        public IntermediateModifierEntry WithStat(IStatBuilder? stat)
         {
             if (Stat != null && stat != null)
                 throw new InvalidOperationException(nameof(WithStat) + " must not be called multiple times");
             return new IntermediateModifierEntry(Form, stat, Value, Condition);
         }
 
-        public IntermediateModifierEntry WithValue(IValueBuilder value)
+        public IntermediateModifierEntry WithValue(IValueBuilder? value)
         {
             if (Value != null && value != null)
                 throw new InvalidOperationException(nameof(WithValue) + " must not be called multiple times");
             return new IntermediateModifierEntry(Form, Stat, value, Condition);
         }
 
-        public IntermediateModifierEntry WithCondition(IConditionBuilder condition)
+        public IntermediateModifierEntry WithCondition(IConditionBuilder? condition)
         {
             if (Condition != null && condition != null)
                 throw new InvalidOperationException(nameof(WithCondition) + " must not be called multiple times");

--- a/PoESkillTree.Engine.Computation.Common/Builders/Modifiers/IntermediateModifierExtensions.cs
+++ b/PoESkillTree.Engine.Computation.Common/Builders/Modifiers/IntermediateModifierExtensions.cs
@@ -77,7 +77,7 @@ namespace PoESkillTree.Engine.Computation.Common.Builders.Modifiers
             if (left.Value != null && right.Value != null)
                 throw new ArgumentException("Value may only be set once");
 
-            IConditionBuilder condition;
+            IConditionBuilder? condition;
             if (left.Condition == null)
             {
                 condition = right.Condition;

--- a/PoESkillTree.Engine.Computation.Common/Builders/Modifiers/IntermediateModifierResolver.cs
+++ b/PoESkillTree.Engine.Computation.Common/Builders/Modifiers/IntermediateModifierResolver.cs
@@ -27,17 +27,17 @@ namespace PoESkillTree.Engine.Computation.Common.Builders.Modifiers
                 .WithForms(Resolve(entries, e => e.Form, context))
                 .WithStats(Resolve(entries, e => e.Stat, context))
                 .WithConditions(Resolve(entries, e => e.Condition, context))
-                .WithValueConverter(v => unresolved.ValueConverter(v)?.Resolve(context))
-                .WithStatConverter(s => unresolved.StatConverter(s)?.Resolve(context))
+                .WithValueConverter(v => unresolved.ValueConverter(v).Resolve(context))
+                .WithStatConverter(s => unresolved.StatConverter(s).Resolve(context))
                 .Build();
         }
 
-        private static IReadOnlyList<T> Resolve<T>(
-            IReadOnlyList<IntermediateModifierEntry> entries, Func<IntermediateModifierEntry, T> selector,
+        private static IReadOnlyList<T?> Resolve<T>(
+            IReadOnlyList<IntermediateModifierEntry> entries, Func<IntermediateModifierEntry, T?> selector,
             ResolveContext context)
-            where T: class, IResolvable<T>
+            where T : class, IResolvable<T>
         {
-            var newEntries = new List<T>(entries.Count);
+            var newEntries = new List<T?>(entries.Count);
             foreach (var entry in entries)
             {
                 newEntries.Add(selector(entry)?.Resolve(context));

--- a/PoESkillTree.Engine.Computation.Common/Builders/Modifiers/ModifierBuilder.cs
+++ b/PoESkillTree.Engine.Computation.Common/Builders/Modifiers/ModifierBuilder.cs
@@ -31,13 +31,13 @@ namespace PoESkillTree.Engine.Computation.Common.Builders.Modifiers
         public IModifierBuilder WithForm(IFormBuilder form)
             => WithSingle(form, (e, f) => e.WithForm(f));
 
-        public IModifierBuilder WithForms(IReadOnlyList<IFormBuilder> forms)
+        public IModifierBuilder WithForms(IReadOnlyList<IFormBuilder?> forms)
             => WithEnumerable(forms, (e, f) => e.WithForm(f));
 
         public IModifierBuilder WithStat(IStatBuilder stat)
             => WithSingle(stat, (e, s) => e.WithStat(s));
 
-        public IModifierBuilder WithStats(IReadOnlyList<IStatBuilder> stats)
+        public IModifierBuilder WithStats(IReadOnlyList<IStatBuilder?> stats)
             => WithEnumerable(stats, (e, s) => e.WithStat(s));
 
         public IModifierBuilder WithStatConverter(StatConverter converter)
@@ -46,7 +46,7 @@ namespace PoESkillTree.Engine.Computation.Common.Builders.Modifiers
         public IModifierBuilder WithValue(IValueBuilder value)
             => WithSingle(value, (e, v) => e.WithValue(v));
 
-        public IModifierBuilder WithValues(IReadOnlyList<IValueBuilder> values)
+        public IModifierBuilder WithValues(IReadOnlyList<IValueBuilder?> values)
             => WithEnumerable(values, (e, v) => e.WithValue(v));
 
         public IModifierBuilder WithValueConverter(ValueConverter converter)
@@ -55,7 +55,7 @@ namespace PoESkillTree.Engine.Computation.Common.Builders.Modifiers
         public IModifierBuilder WithCondition(IConditionBuilder condition)
             => WithSingle(condition, (e, c) => e.WithCondition(c));
 
-        public IModifierBuilder WithConditions(IReadOnlyList<IConditionBuilder> conditions)
+        public IModifierBuilder WithConditions(IReadOnlyList<IConditionBuilder?> conditions)
             => WithEnumerable(conditions, (e, c) => e.WithCondition(c));
 
         public IIntermediateModifier Build() => this;

--- a/PoESkillTree.Engine.Computation.Common/Builders/Resolving/IResolvable.cs
+++ b/PoESkillTree.Engine.Computation.Common/Builders/Resolving/IResolvable.cs
@@ -8,7 +8,7 @@ namespace PoESkillTree.Engine.Computation.Common.Builders.Resolving
     /// </summary>
     /// <typeparam name="T">The resulting type of resolving. Generally this is the type that is implementing this
     /// interface.</typeparam>
-    public interface IResolvable<out T>
+    public interface IResolvable<out T> where T : class
     {
         /// <summary>
         /// Resolves this instance using the given match context.

--- a/PoESkillTree.Engine.Computation.Common/Builders/Stats/IStatBuilder.cs
+++ b/PoESkillTree.Engine.Computation.Common/Builders/Stats/IStatBuilder.cs
@@ -38,7 +38,7 @@ namespace PoESkillTree.Engine.Computation.Common.Builders.Stats
         /// Gets this stat's value for the given type and optionally the given ModifierSource (Global if null).
         /// Defaults to null.
         /// </summary>
-        ValueBuilder ValueFor(NodeType nodeType, ModifierSource modifierSource = null);
+        ValueBuilder ValueFor(NodeType nodeType, ModifierSource? modifierSource = null);
 
         /// <summary>
         /// Gets a condition that is satisfied if this stat's value is set, i.e. is not null.

--- a/PoESkillTree.Engine.Computation.Common/IStat.cs
+++ b/PoESkillTree.Engine.Computation.Common/IStat.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using JetBrains.Annotations;
 using PoESkillTree.Engine.GameModel;
 
 namespace PoESkillTree.Engine.Computation.Common
@@ -29,21 +28,18 @@ namespace PoESkillTree.Engine.Computation.Common
         /// The <see cref="IStat"/> determining the minimum value of this stat or <c>null</c> if the stat can never
         /// have an lower bound.
         /// </summary>
-        [CanBeNull]
-        IStat Minimum { get; }
+        IStat? Minimum { get; }
         
         /// <summary>
         /// The <see cref="IStat"/> determining the maximum value of this stat or <c>null</c> if the stat can never
         /// have an upper bound.
         /// </summary>
-        [CanBeNull]
-        IStat Maximum { get; }
+        IStat? Maximum { get; }
 
         /// <summary>
         /// Not null if the existence/usage of this stat should be explicitly announced to clients
         /// </summary>
-        [CanBeNull]
-        ExplicitRegistrationType ExplicitRegistrationType { get; }
+        ExplicitRegistrationType? ExplicitRegistrationType { get; }
 
         /// <summary>
         /// The type of this stat's values. Can be double, int, uint, bool or an enum type.

--- a/PoESkillTree.Engine.Computation.Common/ModifierSource.cs
+++ b/PoESkillTree.Engine.Computation.Common/ModifierSource.cs
@@ -21,7 +21,7 @@ namespace PoESkillTree.Engine.Computation.Common
 #pragma warning restore 660,661
     {
         private ModifierSource(
-            ModifierSource canonicalSource, string sourceName, params ModifierSource[] influencingSources)
+            ModifierSource? canonicalSource, string? sourceName, params ModifierSource[] influencingSources)
         {
             CanonicalSource = canonicalSource ?? this;
             SourceName = sourceName;
@@ -77,7 +77,7 @@ namespace PoESkillTree.Engine.Computation.Common
         /// The detailed name of this source. E.g. tree node names, description of given mods like
         /// "x per y dexterity", item names or skill ids.
         /// </summary>
-        public string SourceName { get; }
+        public string? SourceName { get; }
 
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace PoESkillTree.Engine.Computation.Common
             {
             }
 
-            public Local LocalSource { get; }
+            public Local? LocalSource { get; }
 
             protected override object ToTuple() => (base.ToTuple(), LocalSource);
 
@@ -108,7 +108,7 @@ namespace PoESkillTree.Engine.Computation.Common
         /// </summary>
         public abstract class Local : ModifierSource
         {
-            private Local(ModifierSource canonicalSource, string sourceName)
+            private Local(ModifierSource canonicalSource, string? sourceName)
                 : base(canonicalSource, sourceName, new Global())
             {
             }
@@ -191,7 +191,7 @@ namespace PoESkillTree.Engine.Computation.Common
 
             public sealed class Skill : Local
             {
-                public Skill(string skillId, string displayName) : base(new Skill(skillId), displayName)
+                public Skill(string skillId, string? displayName) : base(new Skill(skillId), displayName)
                 {
                     SkillId = skillId;
                 }
@@ -213,12 +213,12 @@ namespace PoESkillTree.Engine.Computation.Common
             /// </summary>
             public sealed class Gem : Local
             {
-                public Gem(ItemSlot slot, int socketIndex, string skillId, string displayName)
-                    : base(new Gem(slot, socketIndex), displayName)
+                public Gem(ItemSlot slot, int socketIndex, string skillId, string? displayName)
+                    : base(new Gem(slot, socketIndex, skillId), displayName)
                     => (Slot, SocketIndex, SkillId) = (slot, socketIndex, skillId);
 
-                public Gem(ItemSlot slot, int socketIndex)
-                    => (Slot, SocketIndex) = (slot, socketIndex);
+                public Gem(ItemSlot slot, int socketIndex, string skillId)
+                    => (Slot, SocketIndex, SkillId) = (slot, socketIndex, skillId);
 
                 public ItemSlot Slot { get; }
                 public int SocketIndex { get; }

--- a/PoESkillTree.Engine.Computation.Common/NodeValue.cs
+++ b/PoESkillTree.Engine.Computation.Common/NodeValue.cs
@@ -222,10 +222,10 @@ namespace PoESkillTree.Engine.Computation.Common
             return left + right;
         }
 
-        public static NodeValue? Sum(this List<NodeValue?> values, Func<NodeValue, NodeValue> selector = null)
+        public static NodeValue? Sum(this List<NodeValue?> values, Func<NodeValue, NodeValue>? selector = null)
             => values.AggregateOnValues((l, r) => l + r, selector);
 
-        public static NodeValue? Product(this List<NodeValue?> values, Func<NodeValue, NodeValue> selector = null)
+        public static NodeValue? Product(this List<NodeValue?> values, Func<NodeValue, NodeValue>? selector = null)
             => values.AggregateOnValues((l, r) => l * r, selector);
     }
 }

--- a/PoESkillTree.Engine.Computation.Common/PoESkillTree.Engine.Computation.Common.csproj
+++ b/PoESkillTree.Engine.Computation.Common/PoESkillTree.Engine.Computation.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Version>1.0.0</Version>
     <FileVersion>1.0.0.0</FileVersion>

--- a/PoESkillTree.Engine.Computation.Common/PoESkillTree.Engine.Computation.Common.csproj
+++ b/PoESkillTree.Engine.Computation.Common/PoESkillTree.Engine.Computation.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8</LangVersion>
     <Version>1.0.0</Version>
     <FileVersion>1.0.0.0</FileVersion>
 
@@ -17,10 +17,14 @@
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSources>true</IncludeSources>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <WarningsAsErrors>8600;8601;8602;8603;8604;8613;8619;8620;8625</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Enums.NET" Version="2.3.2" />
-    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All" />
     <PackageReference Include="morelinq" Version="3.2.0" />
   </ItemGroup>

--- a/PoESkillTree.Engine.Computation.Common/PoESkillTree.Engine.Computation.Common.csproj
+++ b/PoESkillTree.Engine.Computation.Common/PoESkillTree.Engine.Computation.Common.csproj
@@ -27,6 +27,10 @@
     <PackageReference Include="Enums.NET" Version="2.3.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All" />
     <PackageReference Include="morelinq" Version="3.2.0" />
+    <PackageReference Include="Nullable" Version="1.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PoESkillTree.Engine.Utils\PoESkillTree.Engine.Utils.csproj" />

--- a/PoESkillTree.Engine.Computation.Common/SimpleValues.cs
+++ b/PoESkillTree.Engine.Computation.Common/SimpleValues.cs
@@ -9,7 +9,7 @@ namespace PoESkillTree.Engine.Computation.Common
     {
         private readonly string _identity;
 
-        protected StringIdentityValue(object identity) =>
+        protected StringIdentityValue(object? identity) =>
             _identity = identity?.ToString() ?? "null";
 
         public abstract NodeValue? Calculate(IValueCalculationContext context);

--- a/PoESkillTree.Engine.Computation.Console/PoESkillTree.Engine.Computation.Console.csproj
+++ b/PoESkillTree.Engine.Computation.Console/PoESkillTree.Engine.Computation.Console.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <LangVersion>latest</LangVersion>
     <AssemblyTitle>PoESkillTree.Engine.Computation.Console</AssemblyTitle>

--- a/PoESkillTree.Engine.Computation.Console/PoESkillTree.Engine.Computation.Console.csproj
+++ b/PoESkillTree.Engine.Computation.Console/PoESkillTree.Engine.Computation.Console.csproj
@@ -1,13 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8</LangVersion>
     <AssemblyTitle>PoESkillTree.Engine.Computation.Console</AssemblyTitle>
     <Product>PoESkillTree.Engine.Computation.Console</Product>
     <Copyright>Copyright ©  2017</Copyright>
     <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>8600;8601;8602;8603;8604;8619;8620;8625</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="LibLog" Version="5.0.6">
@@ -18,7 +20,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Enums.NET" Version="2.3.2" />
-    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="morelinq" Version="3.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>

--- a/PoESkillTree.Engine.Computation.Console/PoESkillTree.Engine.Computation.Console.csproj
+++ b/PoESkillTree.Engine.Computation.Console/PoESkillTree.Engine.Computation.Console.csproj
@@ -22,6 +22,10 @@
     <PackageReference Include="Enums.NET" Version="2.3.2" />
     <PackageReference Include="morelinq" Version="3.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Nullable" Version="1.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PoESkillTree.Engine.Utils\PoESkillTree.Engine.Utils.csproj" />

--- a/PoESkillTree.Engine.Computation.Console/PoESkillTree.Engine.Computation.Console.csproj
+++ b/PoESkillTree.Engine.Computation.Console/PoESkillTree.Engine.Computation.Console.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NLog" Version="4.6.6" />
+    <PackageReference Include="NLog" Version="4.6.7" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Enums.NET" Version="2.3.2" />

--- a/PoESkillTree.Engine.Computation.Console/Program.cs
+++ b/PoESkillTree.Engine.Computation.Console/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -248,7 +249,7 @@ namespace PoESkillTree.Engine.Computation.Console
             var (isMetaStat, metaStats) = await TryParseMetaStatAsync(stat);
             if (isMetaStat)
             {
-                return metaStats;
+                return metaStats!;
             }
             var parser = await _compositionRoot.Parser;
             if (TryParse(parser, "1% increased" + stat, out var mods))
@@ -258,7 +259,7 @@ namespace PoESkillTree.Engine.Computation.Console
             return new[] { new Stat(stat.Trim()), };
         }
 
-        private async Task<(bool, IEnumerable<IStat>)> TryParseMetaStatAsync(string stat)
+        private async Task<(bool, IEnumerable<IStat>?)> TryParseMetaStatAsync(string stat)
         {
             var builderFactories = await _compositionRoot.BuilderFactories;
             var metaStats = builderFactories.MetaStatBuilders;
@@ -298,7 +299,7 @@ namespace PoESkillTree.Engine.Computation.Console
         /// Parses the given stat using the given parser and writes results to the console.
         /// </summary>
         private static bool TryParse(
-            IParser parser, string statLine, out IReadOnlyList<Modifier> mods, bool verbose = false)
+            IParser parser, string statLine, [NotNullWhen(true)] out IReadOnlyList<Modifier>? mods, bool verbose = false)
         {
             var result = parser.Parse(statLine);
             if (!result.SuccessfullyParsed)

--- a/PoESkillTree.Engine.Computation.Core.Tests/CalculatorExtensionsTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/CalculatorExtensionsTest.cs
@@ -105,7 +105,7 @@ namespace PoESkillTree.Engine.Computation.Core
         private static readonly CalculatorUpdate EmptyUpdate =
             new CalculatorUpdate(new Modifier[0], new Modifier[0]);
 
-        private static CalculatorUpdate ExpectUpdateFor(Modifier[] adds = null, Modifier[] removes = null) => 
+        private static CalculatorUpdate ExpectUpdateFor(Modifier[]? adds = null, Modifier[]? removes = null) => 
             new CalculatorUpdate(adds ?? new Modifier[0], removes ?? new Modifier[0]);
     }
 }

--- a/PoESkillTree.Engine.Computation.Core.Tests/CalculatorTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/CalculatorTest.cs
@@ -51,7 +51,7 @@ namespace PoESkillTree.Engine.Computation.Core
             var addedModifiers = Helper.MockManyModifiers();
             var removedModifiers = Helper.MockManyModifiers();
             var modifierCollectionMock = new Mock<IModifierCollection>();
-            var sut = CreateSut(modifierCollectionMock.Object, Mock.Of<ICalculationGraphPruner>());
+            var sut = CreateSut(modifierCollectionMock.Object);
 
             sut.Update(new CalculatorUpdate(addedModifiers, removedModifiers));
 
@@ -73,7 +73,10 @@ namespace PoESkillTree.Engine.Computation.Core
         private static Calculator CreateSut(
             IModifierCollection? modifierCollection = null, ICalculationGraphPruner? graphPruner = null,
             INodeRepository? nodeRepository = null, INodeCollection<IStat>? explicitlyRegisteredStats = null)
-            => new Calculator(new EventBuffer(), modifierCollection, graphPruner, nodeRepository,
-                explicitlyRegisteredStats);
+            => new Calculator(new EventBuffer(),
+                modifierCollection ?? Mock.Of<IModifierCollection>(),
+                graphPruner ?? Mock.Of<ICalculationGraphPruner>(),
+                nodeRepository ?? Mock.Of<INodeRepository>(),
+                explicitlyRegisteredStats ?? Mock.Of<INodeCollection<IStat>>());
     }
 }

--- a/PoESkillTree.Engine.Computation.Core.Tests/CalculatorTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/CalculatorTest.cs
@@ -71,8 +71,8 @@ namespace PoESkillTree.Engine.Computation.Core
         }
 
         private static Calculator CreateSut(
-            IModifierCollection modifierCollection = null, ICalculationGraphPruner graphPruner = null,
-            INodeRepository nodeRepository = null, INodeCollection<IStat> explicitlyRegisteredStats = null)
+            IModifierCollection? modifierCollection = null, ICalculationGraphPruner? graphPruner = null,
+            INodeRepository? nodeRepository = null, INodeCollection<IStat>? explicitlyRegisteredStats = null)
             => new Calculator(new EventBuffer(), modifierCollection, graphPruner, nodeRepository,
                 explicitlyRegisteredStats);
     }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Graphs/CalculationGraphWithEventsTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Graphs/CalculationGraphWithEventsTest.cs
@@ -203,12 +203,12 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
         }
 
         private static CalculationGraphWithEvents CreateSut(
-            Action<IStat> statAddedAction = null, Action<IStat> statRemovedAction = null, params IStat[] knownStats) =>
+            Action<IStat>? statAddedAction = null, Action<IStat>? statRemovedAction = null, params IStat[] knownStats) =>
             CreateSut(MockGraph(knownStats), statAddedAction, statRemovedAction);
 
         private static CalculationGraphWithEvents CreateSut(
             ICalculationGraph decoratedGraph,
-            Action<IStat> statAddedAction = null, Action<IStat> statRemovedAction = null)
+            Action<IStat>? statAddedAction = null, Action<IStat>? statRemovedAction = null)
         {
             var sut = new CalculationGraphWithEvents(decoratedGraph);
             if (statAddedAction != null)

--- a/PoESkillTree.Engine.Computation.Core.Tests/Graphs/CoreCalculationGraphTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Graphs/CoreCalculationGraphTest.cs
@@ -153,7 +153,7 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
         }
 
         private static CoreCalculationGraph CreateSut(
-            Func<IStat, IStatGraph> graphFactory = null, INodeFactory nodeFactory = null) =>
+            Func<IStat, IStatGraph>? graphFactory = null, INodeFactory? nodeFactory = null) =>
             new CoreCalculationGraph(graphFactory, nodeFactory);
     }
 }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Graphs/CoreCalculationGraphTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Graphs/CoreCalculationGraphTest.cs
@@ -154,6 +154,6 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
 
         private static CoreCalculationGraph CreateSut(
             Func<IStat, IStatGraph>? graphFactory = null, INodeFactory? nodeFactory = null) =>
-            new CoreCalculationGraph(graphFactory, nodeFactory);
+            new CoreCalculationGraph(graphFactory!, nodeFactory!);
     }
 }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Graphs/CoreStatGraphTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Graphs/CoreStatGraphTest.cs
@@ -321,7 +321,7 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
         }
 
         private static CoreStatGraph CreateSut(
-            IStatNodeFactory nodeFactory = null, PathDefinitionCollection paths = null) =>
+            IStatNodeFactory? nodeFactory = null, PathDefinitionCollection? paths = null) =>
             new CoreStatGraph(nodeFactory ?? Mock.Of<IStatNodeFactory>(), paths ?? CreatePathDefinitionCollection());
 
         private static ModifierNodeCollection MockModifierNodeCollection()

--- a/PoESkillTree.Engine.Computation.Core.Tests/Graphs/PrunableCalculationGraphTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Graphs/PrunableCalculationGraphTest.cs
@@ -293,13 +293,12 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
         }
 
         private static IStatGraph MockStatGraph(
-            IReadOnlyDictionary<NodeSelector, IBufferingEventViewProvider<ICalculationNode>> nodes = null,
-            IReadOnlyDictionary<FormNodeSelector, IBufferingEventViewProvider<INodeCollection<Modifier>>> formNodes
+            IReadOnlyDictionary<NodeSelector, IBufferingEventViewProvider<ICalculationNode>>? nodes = null,
+            IReadOnlyDictionary<FormNodeSelector, IBufferingEventViewProvider<INodeCollection<Modifier>>>? formNodes
                 = null)
         {
-            nodes = nodes ?? new Dictionary<NodeSelector, IBufferingEventViewProvider<ICalculationNode>>();
-            formNodes = formNodes ??
-                        new Dictionary<FormNodeSelector, IBufferingEventViewProvider<INodeCollection<Modifier>>>();
+            nodes ??= new Dictionary<NodeSelector, IBufferingEventViewProvider<ICalculationNode>>();
+            formNodes ??= new Dictionary<FormNodeSelector, IBufferingEventViewProvider<INodeCollection<Modifier>>>();
             return Mock.Of<IStatGraph>(g =>
                 g.Nodes == nodes &&
                 g.FormNodeCollections == formNodes &&

--- a/PoESkillTree.Engine.Computation.Core.Tests/Graphs/PrunableCalculationGraphTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Graphs/PrunableCalculationGraphTest.cs
@@ -237,7 +237,7 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
                 r.CanStatBeConsideredForRemoval(stat, statGraphMock.Object) &&
                 r.CanStatGraphBeRemoved(statGraphMock.Object));
             var formNodeSelector = new FormNodeSelector(Form.TotalOverride, PathDefinition.MainPath);
-            var modifierNodeCollection = new StatNodeFactory(new EventBuffer(), null, stat)
+            var modifierNodeCollection = new StatNodeFactory(new EventBuffer(), null!, stat)
                 .Create(formNodeSelector);
             modifierNodeCollection.Add(MockProvider<ICalculationNode>(), modifier);
             var formNodeCollection =

--- a/PoESkillTree.Engine.Computation.Core.Tests/Graphs/StatGraphWithEventsTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Graphs/StatGraphWithEventsTest.cs
@@ -85,7 +85,7 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
         private static StatGraphWithEvents CreateSut(IStatGraph decoratedGraph, 
             Action<NodeSelector>? nodeAddedAction = null, Action<NodeSelector>? nodeRemovedAction = null)
         {
-            return new StatGraphWithEvents(decoratedGraph, nodeAddedAction, nodeRemovedAction);
+            return new StatGraphWithEvents(decoratedGraph, nodeAddedAction!, nodeRemovedAction!);
         }
     }
 }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Graphs/StatGraphWithEventsTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Graphs/StatGraphWithEventsTest.cs
@@ -76,14 +76,14 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
         }
 
         private static StatGraphWithEvents CreateSut(
-            Action<NodeSelector> nodeAddedAction = null, Action<NodeSelector> nodeRemovedAction = null)
+            Action<NodeSelector>? nodeAddedAction = null, Action<NodeSelector>? nodeRemovedAction = null)
         {
             var nodes = new Dictionary<NodeSelector, IBufferingEventViewProvider<ICalculationNode>>();
             return CreateSut(Mock.Of<IStatGraph>(g => g.Nodes == nodes), nodeAddedAction, nodeRemovedAction);
         }
 
         private static StatGraphWithEvents CreateSut(IStatGraph decoratedGraph, 
-            Action<NodeSelector> nodeAddedAction = null, Action<NodeSelector> nodeRemovedAction = null)
+            Action<NodeSelector>? nodeAddedAction = null, Action<NodeSelector>? nodeRemovedAction = null)
         {
             return new StatGraphWithEvents(decoratedGraph, nodeAddedAction, nodeRemovedAction);
         }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Graphs/StatRegistryTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Graphs/StatRegistryTest.cs
@@ -138,8 +138,8 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
         }
 
         private static StatRegistry CreateSut(
-            NodeCollection<IStat> nodeCollection = null,
-            INodeRepository nodeRepository = null)
+            NodeCollection<IStat>? nodeCollection = null,
+            INodeRepository? nodeRepository = null)
         {
             return new StatRegistry(nodeCollection ?? CreateNodeCollection())
             {

--- a/PoESkillTree.Engine.Computation.Core.Tests/Graphs/TransformableNodeFactoryTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Graphs/TransformableNodeFactoryTest.cs
@@ -24,7 +24,7 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
             var value = Mock.Of<IValue>();
             var sut = CreateSut(new TransformableValue(value), expected);
 
-            var actual = sut.Create(value, null);
+            var actual = sut.Create(value, null!);
 
             Assert.AreSame(expected, actual);
         }
@@ -41,10 +41,10 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
         public void CreateAddsToTransformableDictionary()
         {
             var key = Mock.Of<IDisposableNodeViewProvider>();
-            var transformableValue = new TransformableValue(null);
+            var transformableValue = new TransformableValue(null!);
             var sut = CreateSut(transformableValue, key);
 
-            sut.Create(null, null);
+            sut.Create(null!, null!);
 
             Assert.IsTrue(sut.TransformableDictionary.ContainsKey(key));
             Assert.AreSame(transformableValue, sut.TransformableDictionary[key]);
@@ -55,7 +55,7 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
         {
             var providerMock = new Mock<IDisposableNodeViewProvider>();
             var sut = CreateSut(provider: providerMock.Object);
-            sut.Create(null, null);
+            sut.Create(null!, null!);
 
             providerMock.Raise(p => p.Disposed += null, EventArgs.Empty);
 
@@ -65,10 +65,10 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
         [Test]
         public void RaisingTransformableValuesValueChangedCallsProvidersRaiseValueChanged()
         {
-            var transformableValue = new TransformableValue(null);
+            var transformableValue = new TransformableValue(null!);
             var providerMock = new Mock<IDisposableNodeViewProvider>();
             var sut = CreateSut(transformableValue, providerMock.Object);
-            sut.Create(null, null);
+            sut.Create(null!, null!);
 
             transformableValue.RemoveAll();
 
@@ -78,10 +78,10 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
         [Test]
         public void RaisingTransformableValuesValueChangedDoesNotCallProvidersRaiseValueChangedAfterDisposal()
         {
-            var transformableValue = new TransformableValue(null);
+            var transformableValue = new TransformableValue(null!);
             var providerMock = new Mock<IDisposableNodeViewProvider>();
             var sut = CreateSut(transformableValue, providerMock.Object);
-            sut.Create(null, null);
+            sut.Create(null!, null!);
             
             providerMock.Raise(p => p.Disposed += null, EventArgs.Empty);
             transformableValue.RemoveAll();
@@ -92,8 +92,8 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
         private static TransformableNodeFactory CreateSut(
             TransformableValue? transformableValue = null, IDisposableNodeViewProvider? provider = null)
         {
-            transformableValue ??= new TransformableValue(null);
-            var injectedFactory = Mock.Of<INodeFactory>(f => f.Create(transformableValue, null) == provider);
+            transformableValue ??= new TransformableValue(null!);
+            var injectedFactory = Mock.Of<INodeFactory>(f => f.Create(transformableValue, null!) == provider);
             return new TransformableNodeFactory(injectedFactory, _ => transformableValue);
         }
     }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Graphs/TransformableNodeFactoryTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Graphs/TransformableNodeFactoryTest.cs
@@ -90,9 +90,9 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
         }
 
         private static TransformableNodeFactory CreateSut(
-            TransformableValue transformableValue = null, IDisposableNodeViewProvider provider = null)
+            TransformableValue? transformableValue = null, IDisposableNodeViewProvider? provider = null)
         {
-            transformableValue = transformableValue ?? new TransformableValue(null);
+            transformableValue ??= new TransformableValue(null);
             var injectedFactory = Mock.Of<INodeFactory>(f => f.Create(transformableValue, null) == provider);
             return new TransformableNodeFactory(injectedFactory, _ => transformableValue);
         }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Graphs/UserSpecifiedValuePruningRuleSetTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Graphs/UserSpecifiedValuePruningRuleSetTest.cs
@@ -21,7 +21,7 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
             {
                 new StatStub
                 {
-                    ExplicitRegistrationType = GainOnAction(null, "", default)
+                    ExplicitRegistrationType = GainOnAction(null!, "", default)
                 },
                 new StatStub
                 {
@@ -32,7 +32,7 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
             var expected = new[] { stats[1] };
             var sut = CreateSut();
 
-            var actual = stats.Where(s => sut.CanStatBeConsideredForRemoval(s, null));
+            var actual = stats.Where(s => sut.CanStatBeConsideredForRemoval(s, null!));
 
             Assert.AreEqual(expected, actual);
         }
@@ -64,7 +64,7 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
                     {
                         defaultResult[0],
                         Mock.Of<IBufferingEventViewProvider<INodeCollection<Modifier>>>(p =>
-                            p.DefaultView == new NodeCollection<Modifier>(eventBuffer) { { null, modifier } })
+                            p.DefaultView == new NodeCollection<Modifier>(eventBuffer) { { null!, modifier } })
                     },
                     {
                         defaultResult[1],

--- a/PoESkillTree.Engine.Computation.Core.Tests/Graphs/UserSpecifiedValuePruningRuleSetTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Graphs/UserSpecifiedValuePruningRuleSetTest.cs
@@ -6,6 +6,7 @@ using PoESkillTree.Engine.Computation.Common;
 using PoESkillTree.Engine.Computation.Core.Events;
 using PoESkillTree.Engine.Computation.Core.NodeCollections;
 using static PoESkillTree.Engine.Computation.Common.ExplicitRegistrationTypes;
+using static PoESkillTree.Engine.Computation.Common.Helper;
 using static PoESkillTree.Engine.Computation.Core.Graphs.NodeSelectorHelper;
 
 namespace PoESkillTree.Engine.Computation.Core.Graphs
@@ -56,13 +57,14 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
             var defaultResult = new[] { Selector(Form.BaseSet), Selector(Form.More) };
             var expected = new[] { defaultResult[1] };
             var eventBuffer = new EventBuffer();
+            var modifier = MockModifier();
             var formNodeCollections =
                 new Dictionary<FormNodeSelector, IBufferingEventViewProvider<INodeCollection<Modifier>>>
                 {
                     {
                         defaultResult[0],
                         Mock.Of<IBufferingEventViewProvider<INodeCollection<Modifier>>>(p =>
-                            p.DefaultView == new NodeCollection<Modifier>(eventBuffer) { { null, null } })
+                            p.DefaultView == new NodeCollection<Modifier>(eventBuffer) { { null, modifier } })
                     },
                     {
                         defaultResult[1],
@@ -115,7 +117,7 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
         }
 
         private static UserSpecifiedValuePruningRuleSet CreateSut(
-            IGraphPruningRuleSet defaultRuleSet = null, IDeterminesNodeRemoval nodeRemovalDeterminer = null)
+            IGraphPruningRuleSet? defaultRuleSet = null, IDeterminesNodeRemoval? nodeRemovalDeterminer = null)
             => new UserSpecifiedValuePruningRuleSet(defaultRuleSet ?? Mock.Of<IGraphPruningRuleSet>(),
                 nodeRemovalDeterminer ?? Mock.Of<IDeterminesNodeRemoval>());
 

--- a/PoESkillTree.Engine.Computation.Core.Tests/Graphs/ValueTransformerTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Graphs/ValueTransformerTest.cs
@@ -12,6 +12,7 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
     [TestFixture]
     public class ValueTransformerTest
     {
+#pragma warning disable 8618 // Initialized in SetUp
         private IReadOnlyList<Mock<IValueTransformable>> _transformableMocks;
         private IStat _stat;
         private NodeType _nodeType;
@@ -19,6 +20,7 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
         private IReadOnlyList<IValueTransformation> _transformations;
         private IReadOnlyList<Behavior> _behaviors;
         private ValueTransformer _sut;
+#pragma warning restore
 
         [SetUp]
         public void SetUp()

--- a/PoESkillTree.Engine.Computation.Core.Tests/NodeCollections/EventBufferingObservableCollectionTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/NodeCollections/EventBufferingObservableCollectionTest.cs
@@ -80,7 +80,7 @@ namespace PoESkillTree.Engine.Computation.Core.NodeCollections
             Assert.IsTrue(raised);
         }
 
-        private static EventBufferingObservableCollection<int> CreateSut(IEventBuffer eventBuffer = null)
+        private static EventBufferingObservableCollection<int> CreateSut(IEventBuffer? eventBuffer = null)
             => new EventBufferingObservableCollection<int>(eventBuffer ?? new EventBuffer());
     }
 }

--- a/PoESkillTree.Engine.Computation.Core.Tests/NodeCollections/ModifierNodeCollectionTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/NodeCollections/ModifierNodeCollectionTest.cs
@@ -14,7 +14,7 @@ namespace PoESkillTree.Engine.Computation.Core.NodeCollections
         public void DefaultViewReturnsConstructorParameter()
         {
             var defaultView = CreateNodeCollection();
-            var sut = CreateSut(defaultView, null);
+            var sut = CreateSut(defaultView, CreateNodeCollection());
 
             Assert.AreSame(defaultView, sut.DefaultView);
         }
@@ -23,7 +23,7 @@ namespace PoESkillTree.Engine.Computation.Core.NodeCollections
         public void BufferingViewReturnsConstructorParameter()
         {
             var bufferingView = CreateNodeCollection();
-            var sut = CreateSut(null, bufferingView);
+            var sut = CreateSut(CreateNodeCollection(), bufferingView);
 
             Assert.AreSame(bufferingView, sut.BufferingView);
         }

--- a/PoESkillTree.Engine.Computation.Core.Tests/NodeHelper.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/NodeHelper.cs
@@ -38,10 +38,10 @@ namespace PoESkillTree.Engine.Computation.Core
                 p.DefaultView == MockNode(0) && p.BufferingView == MockNode(0));
 
         public static IBufferingEventViewProvider<ICalculationNode> MockNodeProvider(
-            ICalculationNode defaultNode = null, ICalculationNode bufferingView = null)
+            ICalculationNode? defaultNode = null, ICalculationNode? bufferingView = null)
         {
-            defaultNode = defaultNode ?? MockNode();
-            bufferingView = bufferingView ?? MockNode();
+            defaultNode ??= MockNode();
+            bufferingView ??= MockNode();
             return Mock.Of<IBufferingEventViewProvider<ICalculationNode>>(
                 p => p.DefaultView == defaultNode && p.BufferingView == bufferingView);
         }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/BaseValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/BaseValueTest.cs
@@ -32,7 +32,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
             Assert.AreEqual((NodeValue?) expected, actual);
         }
 
-        private static BaseValue CreateSut(IStat stat = null) =>
+        private static BaseValue CreateSut(IStat? stat = null) =>
             new BaseValue(stat, Path);
 
         private static readonly PathDefinition Path = NodeHelper.NotMainPath;

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/BaseValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/BaseValueTest.cs
@@ -33,7 +33,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
         }
 
         private static BaseValue CreateSut(IStat? stat = null) =>
-            new BaseValue(stat, Path);
+            new BaseValue(stat ?? new StatStub(), Path);
 
         private static readonly PathDefinition Path = NodeHelper.NotMainPath;
     }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/CachingNodeTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/CachingNodeTest.cs
@@ -159,14 +159,14 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
             return sut;
         }
 
-        private static CachingNode CreateSut(double? value = null, ICycleGuard cycleGuard = null)
+        private static CachingNode CreateSut(double? value = null, ICycleGuard? cycleGuard = null)
         {
             var decoratedNode = NodeHelper.MockNode(value);
             return CreateSut(decoratedNode, cycleGuard);
         }
 
         private static CachingNode CreateSut(
-            ICalculationNode decoratedNode, ICycleGuard cycleGuard = null, IEventBuffer eventBuffer = null)
+            ICalculationNode decoratedNode, ICycleGuard? cycleGuard = null, IEventBuffer? eventBuffer = null)
             => new CachingNode(decoratedNode, cycleGuard ?? Mock.Of<ICycleGuard>(), eventBuffer ?? new EventBuffer());
     }
 }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/ConvertedBaseValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/ConvertedBaseValueTest.cs
@@ -34,6 +34,6 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
         }
 
         private static ConvertedBaseValue CreateSut(PathDefinition? path = null) =>
-            new ConvertedBaseValue(path);
+            new ConvertedBaseValue(path ?? PathDefinition.MainPath);
     }
 }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/ConvertedBaseValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/ConvertedBaseValueTest.cs
@@ -33,7 +33,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
             Assert.AreEqual(expected, actual);
         }
 
-        private static ConvertedBaseValue CreateSut(PathDefinition path = null) =>
+        private static ConvertedBaseValue CreateSut(PathDefinition? path = null) =>
             new ConvertedBaseValue(path);
     }
 }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/FormAggregatingValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/FormAggregatingValueTest.cs
@@ -35,7 +35,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
         }
 
         private static FormAggregatingValue CreateSut(
-            IStat stat = null, Form form = Form.More, PathDefinition path = null) =>
+            IStat? stat = null, Form form = Form.More, PathDefinition? path = null) =>
             new FormAggregatingValue(stat ?? new StatStub(), form, path, Aggregate);
 
         private static NodeValue? Aggregate(IEnumerable<NodeValue?> vs) =>

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/FormAggregatingValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/FormAggregatingValueTest.cs
@@ -36,7 +36,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
 
         private static FormAggregatingValue CreateSut(
             IStat? stat = null, Form form = Form.More, PathDefinition? path = null) =>
-            new FormAggregatingValue(stat ?? new StatStub(), form, path, Aggregate);
+            new FormAggregatingValue(stat ?? new StatStub(), form, path ?? PathDefinition.MainPath, Aggregate);
 
         private static NodeValue? Aggregate(IEnumerable<NodeValue?> vs) =>
             vs.OfType<NodeValue>().Aggregate(new NodeValue(0), (l, r) => l + r);

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/MultiPathFormAggregatingValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/MultiPathFormAggregatingValueTest.cs
@@ -42,7 +42,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
             Assert.AreEqual(expected, actual);
         }
 
-        private static MultiPathFormAggregatingValue CreateSut(IStat stat = null, PathDefinition path = null) => 
+        private static MultiPathFormAggregatingValue CreateSut(IStat? stat = null, PathDefinition? path = null) => 
             new MultiPathFormAggregatingValue(stat, Form.More, path, vs => vs.Sum());
     }
 }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/MultiPathFormAggregatingValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/MultiPathFormAggregatingValueTest.cs
@@ -42,7 +42,8 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
             Assert.AreEqual(expected, actual);
         }
 
-        private static MultiPathFormAggregatingValue CreateSut(IStat? stat = null, PathDefinition? path = null) => 
-            new MultiPathFormAggregatingValue(stat, Form.More, path, vs => vs.Sum());
+        private static MultiPathFormAggregatingValue CreateSut(IStat? stat = null, PathDefinition? path = null) =>
+            new MultiPathFormAggregatingValue(stat ?? new StatStub(), Form.More, path ?? PathDefinition.MainPath,
+                vs => vs.Sum());
     }
 }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/PathTotalValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/PathTotalValueTest.cs
@@ -33,7 +33,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
             Assert.AreEqual((NodeValue?) expected, actual);
         }
 
-        private static PathTotalValue CreateSut(IStat stat = null) =>
+        private static PathTotalValue CreateSut(IStat? stat = null) =>
             new PathTotalValue(stat, Path);
 
         private static readonly PathDefinition Path = NodeHelper.NotMainPath;

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/PathTotalValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/PathTotalValueTest.cs
@@ -34,7 +34,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
         }
 
         private static PathTotalValue CreateSut(IStat? stat = null) =>
-            new PathTotalValue(stat, Path);
+            new PathTotalValue(stat ?? new StatStub(), Path);
 
         private static readonly PathDefinition Path = NodeHelper.NotMainPath;
     }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/SubtotalValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/SubtotalValueTest.cs
@@ -53,7 +53,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
             Assert.AreEqual(expected, actual);
         }
 
-        private static SubtotalValue CreateSut(IStat stat = null) =>
+        private static SubtotalValue CreateSut(IStat? stat = null) =>
             new SubtotalValue(stat);
 
         private static readonly PathDefinition Path = PathDefinition.MainPath;

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/SubtotalValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/SubtotalValueTest.cs
@@ -44,8 +44,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
             var expected = new NodeValue(5);
             var stat = new StatStub();
             var context = Mock.Of<IValueCalculationContext>(c =>
-                c.GetValue(stat, NodeType.UncappedSubtotal, Path) == expected &&
-                c.GetValue(null, NodeType.Total, Path) == new NodeValue(0));
+                c.GetValue(stat, NodeType.UncappedSubtotal, Path) == expected);
             var sut = CreateSut(stat);
 
             var actual = sut.Calculate(context);
@@ -54,7 +53,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
         }
 
         private static SubtotalValue CreateSut(IStat? stat = null) =>
-            new SubtotalValue(stat);
+            new SubtotalValue(stat ?? new StatStub());
 
         private static readonly PathDefinition Path = PathDefinition.MainPath;
     }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/TotalValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/TotalValueTest.cs
@@ -32,7 +32,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
         }
 
         private static TotalValue CreateSut(IStat? stat = null) =>
-            new TotalValue(stat);
+            new TotalValue(stat ?? new StatStub());
 
         private static readonly PathDefinition Path = PathDefinition.MainPath;
     }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/TotalValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/TotalValueTest.cs
@@ -31,7 +31,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
             Assert.AreEqual((NodeValue?) expected, actual);
         }
 
-        private static TotalValue CreateSut(IStat stat = null) =>
+        private static TotalValue CreateSut(IStat? stat = null) =>
             new TotalValue(stat);
 
         private static readonly PathDefinition Path = PathDefinition.MainPath;

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/TransformableValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/TransformableValueTest.cs
@@ -109,7 +109,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
             var raised = false;
             sut.ValueChanged += (sender, args) => raised = true;
 
-            sut.Remove(null);
+            sut.Remove(null!);
             
             Assert.IsTrue(raised);
         }
@@ -126,6 +126,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
             Assert.IsTrue(raised);
         }
 
-        private static TransformableValue CreateSut(IValue? value = null) => new TransformableValue(value);
+        private static TransformableValue CreateSut(IValue? value = null)
+            => new TransformableValue(value ?? new Constant(true));
     }
 }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/TransformableValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/TransformableValueTest.cs
@@ -126,6 +126,6 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
             Assert.IsTrue(raised);
         }
 
-        private static TransformableValue CreateSut(IValue value = null) => new TransformableValue(value);
+        private static TransformableValue CreateSut(IValue? value = null) => new TransformableValue(value);
     }
 }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/UncappedSubtotalValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/UncappedSubtotalValueTest.cs
@@ -37,6 +37,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
             Assert.AreEqual((NodeValue?) expected, actual);
         }
 
-        private static UncappedSubtotalValue CreateSut(IStat? stat = null) => new UncappedSubtotalValue(stat);
+        private static UncappedSubtotalValue CreateSut(IStat? stat = null)
+            => new UncappedSubtotalValue(stat ?? new StatStub());
     }
 }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/UncappedSubtotalValueTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/UncappedSubtotalValueTest.cs
@@ -37,6 +37,6 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
             Assert.AreEqual((NodeValue?) expected, actual);
         }
 
-        private static UncappedSubtotalValue CreateSut(IStat stat = null) => new UncappedSubtotalValue(stat);
+        private static UncappedSubtotalValue CreateSut(IStat? stat = null) => new UncappedSubtotalValue(stat);
     }
 }

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/ValueCalculationContextTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/ValueCalculationContextTest.cs
@@ -2,6 +2,7 @@
 using Moq;
 using NUnit.Framework;
 using PoESkillTree.Engine.Computation.Common;
+using static PoESkillTree.Engine.Computation.Common.Helper;
 using static PoESkillTree.Engine.Computation.Core.NodeHelper;
 
 namespace PoESkillTree.Engine.Computation.Core.Nodes
@@ -195,14 +196,14 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
         }
 
 
-        private static ValueCalculationContext CreateSut(INodeRepository nodeRepository = null) =>
+        private static ValueCalculationContext CreateSut(INodeRepository? nodeRepository = null) =>
             new ValueCalculationContext(nodeRepository, null);
 
         private static INodeCollection<Modifier> MockNodeCollection(params ICalculationNode[] nodes)
         {
             var mock = new Mock<INodeCollection<Modifier>>();
             mock.Setup(c => c.GetEnumerator())
-                .Returns(() => nodes.Select(n => (n, (Modifier) null)).GetEnumerator());
+                .Returns(() => nodes.Select(n => (n, MockModifier())).GetEnumerator());
             return mock.Object;
         }
 

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/ValueCalculationContextTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/ValueCalculationContextTest.cs
@@ -197,7 +197,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
 
 
         private static ValueCalculationContext CreateSut(INodeRepository? nodeRepository = null) =>
-            new ValueCalculationContext(nodeRepository, null);
+            new ValueCalculationContext(nodeRepository!, null!);
 
         private static INodeCollection<Modifier> MockNodeCollection(params ICalculationNode[] nodes)
         {

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/ValueNodeTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/ValueNodeTest.cs
@@ -158,7 +158,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
             return CreateSut(nodeRepository, valueMock.Object);
         }
 
-        private static ValueNode CreateSut(INodeRepository nodeRepository = null, IValue value = null)
+        private static ValueNode CreateSut(INodeRepository? nodeRepository = null, IValue? value = null)
             => new ValueNode(new ValueCalculationContext(nodeRepository, null),
                 new ValueCalculationContext(nodeRepository, null), value);
 

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/ValueNodeTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/ValueNodeTest.cs
@@ -159,8 +159,8 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
         }
 
         private static ValueNode CreateSut(INodeRepository? nodeRepository = null, IValue? value = null)
-            => new ValueNode(new ValueCalculationContext(nodeRepository, null),
-                new ValueCalculationContext(nodeRepository, null), value);
+            => new ValueNode(new ValueCalculationContext(nodeRepository!, null!),
+                new ValueCalculationContext(nodeRepository!, null!), value!);
 
         private static readonly CollectionChangeEventArgs RefreshEventArgs =
             new CollectionChangeEventArgs(CollectionChangeAction.Refresh, null);

--- a/PoESkillTree.Engine.Computation.Core.Tests/Nodes/WrappingNodeTest.cs
+++ b/PoESkillTree.Engine.Computation.Core.Tests/Nodes/WrappingNodeTest.cs
@@ -49,7 +49,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
             nodeMock.Raise(n => n.ValueChanged += null, EventArgs.Empty);
         }
 
-        private static WrappingNode CreateSut(ICalculationNode decoratedNode = null) =>
+        private static WrappingNode CreateSut(ICalculationNode? decoratedNode = null) =>
             new WrappingNode(decoratedNode ?? NodeHelper.MockNode());
     }
 }

--- a/PoESkillTree.Engine.Computation.Core.Tests/PoESkillTree.Engine.Computation.Core.Tests.csproj
+++ b/PoESkillTree.Engine.Computation.Core.Tests/PoESkillTree.Engine.Computation.Core.Tests.csproj
@@ -2,11 +2,13 @@
   <PropertyGroup>
     <RootNamespace>PoESkillTree.Engine.Computation.Core</RootNamespace>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8</LangVersion>
     <AssemblyTitle>PoESkillTree.Engine.Computation.Core.Tests</AssemblyTitle>
     <Product>PoESkillTree.Engine.Computation.Core.Tests</Product>
     <Copyright>Copyright ©  2018</Copyright>
     <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>8600;8601;8602;8603;8604;8619;8620</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/PoESkillTree.Engine.Computation.Core.Tests/PoESkillTree.Engine.Computation.Core.Tests.csproj
+++ b/PoESkillTree.Engine.Computation.Core.Tests/PoESkillTree.Engine.Computation.Core.Tests.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.12.0" />
+    <PackageReference Include="Moq" Version="4.13.0" />
     <PackageReference Include="morelinq" Version="3.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PoESkillTree.Engine.GameModel\PoESkillTree.Engine.GameModel.csproj" />

--- a/PoESkillTree.Engine.Computation.Core.Tests/PoESkillTree.Engine.Computation.Core.Tests.csproj
+++ b/PoESkillTree.Engine.Computation.Core.Tests/PoESkillTree.Engine.Computation.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>PoESkillTree.Engine.Computation.Core</RootNamespace>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyTitle>PoESkillTree.Engine.Computation.Core.Tests</AssemblyTitle>
     <Product>PoESkillTree.Engine.Computation.Core.Tests</Product>

--- a/PoESkillTree.Engine.Computation.Core/Graphs/CalculationGraphWithEvents.cs
+++ b/PoESkillTree.Engine.Computation.Core/Graphs/CalculationGraphWithEvents.cs
@@ -63,9 +63,9 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
             StatRemoved?.Invoke(stat);
         }
 
-        public event Action<IStat> StatAdded;
-        public event Action<IStat> StatRemoved;
-        public event Action<Modifier> ModifierAdded;
-        public event Action<Modifier> ModifierRemoved;
+        public event Action<IStat>? StatAdded;
+        public event Action<IStat>? StatRemoved;
+        public event Action<Modifier>? ModifierAdded;
+        public event Action<Modifier>? ModifierRemoved;
     }
 }

--- a/PoESkillTree.Engine.Computation.Core/Graphs/CoreCalculationGraph.cs
+++ b/PoESkillTree.Engine.Computation.Core/Graphs/CoreCalculationGraph.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using PoESkillTree.Engine.Computation.Common;
 using PoESkillTree.Engine.Computation.Core.Nodes;
 using PoESkillTree.Engine.Utils.Extensions;
@@ -66,8 +67,12 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
             node.Dispose();
         }
 
-        private bool TryGetNodeProvider(
-            Modifier modifier, out IDisposableNodeViewProvider nodeProvider)
+        private bool TryGetNodeProvider(Modifier modifier,
+#if NETSTANDARD2_0
+            out IDisposableNodeViewProvider nodeProvider)
+#else
+            [NotNullWhen(true)] out IDisposableNodeViewProvider? nodeProvider)
+#endif
         {
             if (!_modifierNodes.TryGetValue(modifier, out var stack))
             {

--- a/PoESkillTree.Engine.Computation.Core/Graphs/CoreCalculationGraph.cs
+++ b/PoESkillTree.Engine.Computation.Core/Graphs/CoreCalculationGraph.cs
@@ -67,12 +67,8 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
             node.Dispose();
         }
 
-        private bool TryGetNodeProvider(Modifier modifier,
-#if NETSTANDARD2_0
-            out IDisposableNodeViewProvider nodeProvider)
-#else
-            [NotNullWhen(true)] out IDisposableNodeViewProvider? nodeProvider)
-#endif
+        private bool TryGetNodeProvider(
+            Modifier modifier, [NotNullWhen(true)] out IDisposableNodeViewProvider? nodeProvider)
         {
             if (!_modifierNodes.TryGetValue(modifier, out var stack))
             {

--- a/PoESkillTree.Engine.Computation.Core/Graphs/StatRegistry.cs
+++ b/PoESkillTree.Engine.Computation.Core/Graphs/StatRegistry.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using PoESkillTree.Engine.Computation.Common;
 using PoESkillTree.Engine.Computation.Core.Events;
 using PoESkillTree.Engine.Computation.Core.NodeCollections;
@@ -34,12 +35,16 @@ namespace PoESkillTree.Engine.Computation.Core.Graphs
             _nodeCollection = nodeCollection;
         }
 
-        public INodeRepository NodeRepository { private get; set; }
+        public INodeRepository? NodeRepository { private get; set; }
 
         public void Add(IStat stat)
         {
             if (stat.ExplicitRegistrationType is null)
                 return;
+
+            if (NodeRepository is null)
+                throw new InvalidOperationException($"{nameof(NodeRepository)} has to be set before calling {nameof(Add)}");
+
             var node = NodeRepository.GetNode(stat);
             _registeredNodeSet.Add(node);
             _registeredNodes[stat] = node;

--- a/PoESkillTree.Engine.Computation.Core/NodeCollections/ObservableCollection.cs
+++ b/PoESkillTree.Engine.Computation.Core/NodeCollections/ObservableCollection.cs
@@ -39,8 +39,8 @@ namespace PoESkillTree.Engine.Computation.Core.NodeCollections
             => (CollectionChanged?.GetInvocationList().Length ?? 0)
                + (UntypedCollectionChanged?.GetInvocationList().Length ?? 0);
 
-        public event CollectionChangedEventHandler<T> CollectionChanged;
-        public event EventHandler UntypedCollectionChanged;
+        public event CollectionChangedEventHandler<T>? CollectionChanged;
+        public event EventHandler? UntypedCollectionChanged;
 
         protected virtual void OnCollectionChanged(CollectionChangedEventArgs<T> e)
         {

--- a/PoESkillTree.Engine.Computation.Core/NodeFactory.cs
+++ b/PoESkillTree.Engine.Computation.Core/NodeFactory.cs
@@ -20,10 +20,13 @@ namespace PoESkillTree.Engine.Computation.Core
         public NodeFactory(IEventBuffer eventBuffer)
             => _eventBuffer = eventBuffer;
 
-        public INodeRepository NodeRepository { private get; set; }
+        public INodeRepository? NodeRepository { private get; set; }
 
         public IDisposableNodeViewProvider Create(IValue value, PathDefinition path)
         {
+            if (NodeRepository is null)
+                throw new InvalidOperationException($"{nameof(NodeRepository)} has to be set before calling {nameof(Create)}");
+
             var coreNode = new ValueNode(new ValueCalculationContext(NodeRepository, path),
                 new ValueCalculationContext(NodeRepository, path), value);
             var cachingNode = new CachingNode(coreNode, new CycleGuard(), _eventBuffer);
@@ -58,7 +61,7 @@ namespace PoESkillTree.Engine.Computation.Core
                 Disposed?.Invoke(this, EventArgs.Empty);
             }
 
-            public event EventHandler Disposed;
+            public event EventHandler? Disposed;
 
             public void RaiseValueChanged() => _valueNode.OnValueChanged();
         }

--- a/PoESkillTree.Engine.Computation.Core/Nodes/CachingNode.cs
+++ b/PoESkillTree.Engine.Computation.Core/Nodes/CachingNode.cs
@@ -50,7 +50,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
             _calculatedValue = true;
         }
 
-        public event EventHandler ValueChangeReceived;
+        public event EventHandler? ValueChangeReceived;
 
         public void Dispose()
         {

--- a/PoESkillTree.Engine.Computation.Core/Nodes/SubscriberCountingNode.cs
+++ b/PoESkillTree.Engine.Computation.Core/Nodes/SubscriberCountingNode.cs
@@ -14,7 +14,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
 
         public int SubscriberCount => ValueChanged?.GetInvocationList().Length ?? 0;
 
-        public event EventHandler ValueChanged;
+        public event EventHandler? ValueChanged;
 
         protected virtual void OnValueChanged()
         {

--- a/PoESkillTree.Engine.Computation.Core/Nodes/TransformableValue.cs
+++ b/PoESkillTree.Engine.Computation.Core/Nodes/TransformableValue.cs
@@ -46,7 +46,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
             OnValueChanged();
         }
 
-        public event EventHandler ValueChanged;
+        public event EventHandler? ValueChanged;
 
         private void OnValueChanged() => ValueChanged?.Invoke(this, EventArgs.Empty);
     }

--- a/PoESkillTree.Engine.Computation.Core/Nodes/ValueNode.cs
+++ b/PoESkillTree.Engine.Computation.Core/Nodes/ValueNode.cs
@@ -32,7 +32,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
             }
         }
 
-        public event EventHandler ValueChanged;
+        public event EventHandler? ValueChanged;
 
         public void Dispose()
         {

--- a/PoESkillTree.Engine.Computation.Core/Nodes/WrappingNode.cs
+++ b/PoESkillTree.Engine.Computation.Core/Nodes/WrappingNode.cs
@@ -23,7 +23,7 @@ namespace PoESkillTree.Engine.Computation.Core.Nodes
 
         public NodeValue? Value => _decoratedNode.Value;
 
-        public event EventHandler ValueChanged;
+        public event EventHandler? ValueChanged;
 
         public void Dispose() => _decoratedNode.ValueChanged -= OnValueChanged;
 

--- a/PoESkillTree.Engine.Computation.Core/PoESkillTree.Engine.Computation.Core.csproj
+++ b/PoESkillTree.Engine.Computation.Core/PoESkillTree.Engine.Computation.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Version>1.0.0</Version>
     <FileVersion>1.0.0.0</FileVersion>

--- a/PoESkillTree.Engine.Computation.Core/PoESkillTree.Engine.Computation.Core.csproj
+++ b/PoESkillTree.Engine.Computation.Core/PoESkillTree.Engine.Computation.Core.csproj
@@ -33,6 +33,10 @@
     <PackageReference Include="Enums.NET" Version="2.3.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All" />
     <PackageReference Include="morelinq" Version="3.2.0" />
+    <PackageReference Include="Nullable" Version="1.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PoESkillTree.Engine.Utils\PoESkillTree.Engine.Utils.csproj" />

--- a/PoESkillTree.Engine.Computation.Core/PoESkillTree.Engine.Computation.Core.csproj
+++ b/PoESkillTree.Engine.Computation.Core/PoESkillTree.Engine.Computation.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8</LangVersion>
     <Version>1.0.0</Version>
     <FileVersion>1.0.0.0</FileVersion>
 
@@ -17,6 +17,11 @@
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSources>true</IncludeSources>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <WarningsAsErrors>8600;8601;8602;8603;8604;8613;8619;8620;8625</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="LibLog" Version="5.0.6">
@@ -26,7 +31,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Enums.NET" Version="2.3.2" />
-    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All" />
     <PackageReference Include="morelinq" Version="3.2.0" />
   </ItemGroup>

--- a/PoESkillTree.Engine.Computation.Data.Tests/Collections/ConditionMatcherCollectionTest.cs
+++ b/PoESkillTree.Engine.Computation.Data.Tests/Collections/ConditionMatcherCollectionTest.cs
@@ -10,7 +10,9 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
     {
         private const string Regex = "regex";
 
+#pragma warning disable 8618 // Initialized in SetUp
         private ConditionMatcherCollection _sut;
+#pragma warning restore
 
         [SetUp]
         public void SetUp()

--- a/PoESkillTree.Engine.Computation.Data.Tests/Collections/EffectStatCollectionTest.cs
+++ b/PoESkillTree.Engine.Computation.Data.Tests/Collections/EffectStatCollectionTest.cs
@@ -10,8 +10,10 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
     [TestFixture]
     public class EffectStatCollectionTest
     {
+#pragma warning disable 8618 // Initialized in SetUp
         private Mock<IValueBuilders> _valueFactory;
         private EffectStatCollection _sut;
+#pragma warning restore
 
         [SetUp]
         public void SetUp()

--- a/PoESkillTree.Engine.Computation.Data.Tests/Collections/FormAndStatMatcherCollectionTest.cs
+++ b/PoESkillTree.Engine.Computation.Data.Tests/Collections/FormAndStatMatcherCollectionTest.cs
@@ -13,8 +13,10 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
     {
         private const string Regex = "regex";
 
+#pragma warning disable 8618 // Initialized in SetUp
         private Mock<IValueBuilders> _valueFactory;
         private FormAndStatMatcherCollection _sut;
+#pragma warning restore
 
         [SetUp]
         public void SetUp()

--- a/PoESkillTree.Engine.Computation.Data.Tests/Collections/FormMatcherCollectionTest.cs
+++ b/PoESkillTree.Engine.Computation.Data.Tests/Collections/FormMatcherCollectionTest.cs
@@ -9,8 +9,10 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
     [TestFixture]
     public class FormMatcherCollectionTest
     {
+#pragma warning disable 8618 // Initialized in SetUp
         private Mock<IValueBuilders> _valueFactory;
         private FormMatcherCollection _sut;
+#pragma warning restore
 
         [SetUp]
         public void SetUp()

--- a/PoESkillTree.Engine.Computation.Data.Tests/Collections/GivenStatsCollectionTest.cs
+++ b/PoESkillTree.Engine.Computation.Data.Tests/Collections/GivenStatsCollectionTest.cs
@@ -10,8 +10,10 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
     [TestFixture]
     public class GivenStatCollectionTest
     {
+#pragma warning disable 8618 // Initialized in SetUp
         private Mock<IValueBuilders> _valueFactory;
         private GivenStatCollection _sut;
+#pragma warning restore
 
         [SetUp]
         public void SetUp()

--- a/PoESkillTree.Engine.Computation.Data.Tests/Collections/ModifierBuilderStub.cs
+++ b/PoESkillTree.Engine.Computation.Data.Tests/Collections/ModifierBuilderStub.cs
@@ -11,15 +11,17 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
 {
     internal class ModifierBuilderStub : IModifierBuilder, IIntermediateModifier
     {
-        internal IEnumerable<IConditionBuilder>? Conditions { get; private set; }
-        internal IEnumerable<IFormBuilder>? Forms { get; private set; }
-        internal IEnumerable<IStatBuilder>? Stats { get; private set; }
-        internal IEnumerable<IValueBuilder>? Values { get; private set; }
+        internal IEnumerable<IConditionBuilder?>? Conditions { get; private set; }
+        internal IEnumerable<IFormBuilder?>? Forms { get; private set; }
+        internal IEnumerable<IStatBuilder?>? Stats { get; private set; }
+        internal IEnumerable<IValueBuilder?>? Values { get; private set; }
 
         public IReadOnlyList<IntermediateModifierEntry> Entries => throw new InvalidOperationException();
 
+#pragma warning disable 8613 // This class changes the interface's contract to simplify testing
         public StatConverter? StatConverter { get; private set; }
         public ValueConverter? ValueConverter { get; private set; }
+#pragma warning restore
 
         public IModifierBuilder WithCondition(IConditionBuilder condition)
         {
@@ -32,7 +34,7 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
             return ret;
         }
 
-        public IModifierBuilder WithConditions(IReadOnlyList<IConditionBuilder> conditions)
+        public IModifierBuilder WithConditions(IReadOnlyList<IConditionBuilder?> conditions)
         {
             if (conditions == null)
                 throw new ArgumentNullException(nameof(conditions));
@@ -54,7 +56,7 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
             return ret;
         }
 
-        public IModifierBuilder WithForms(IReadOnlyList<IFormBuilder> forms)
+        public IModifierBuilder WithForms(IReadOnlyList<IFormBuilder?> forms)
         {
             if (forms == null)
                 throw new ArgumentNullException(nameof(forms));
@@ -87,7 +89,7 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
             return ret;
         }
 
-        public IModifierBuilder WithStats(IReadOnlyList<IStatBuilder> stats)
+        public IModifierBuilder WithStats(IReadOnlyList<IStatBuilder?> stats)
         {
             if (stats == null)
                 throw new ArgumentNullException(nameof(stats));
@@ -120,7 +122,7 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
             return ret;
         }
 
-        public IModifierBuilder WithValues(IReadOnlyList<IValueBuilder> values)
+        public IModifierBuilder WithValues(IReadOnlyList<IValueBuilder?> values)
         {
             if (values == null)
                 throw new ArgumentNullException(nameof(values));

--- a/PoESkillTree.Engine.Computation.Data.Tests/Collections/ModifierBuilderStub.cs
+++ b/PoESkillTree.Engine.Computation.Data.Tests/Collections/ModifierBuilderStub.cs
@@ -11,15 +11,15 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
 {
     internal class ModifierBuilderStub : IModifierBuilder, IIntermediateModifier
     {
-        internal IEnumerable<IConditionBuilder> Conditions { get; private set; }
-        internal IEnumerable<IFormBuilder> Forms { get; private set; }
-        internal IEnumerable<IStatBuilder> Stats { get; private set; }
-        internal IEnumerable<IValueBuilder> Values { get; private set; }
+        internal IEnumerable<IConditionBuilder>? Conditions { get; private set; }
+        internal IEnumerable<IFormBuilder>? Forms { get; private set; }
+        internal IEnumerable<IStatBuilder>? Stats { get; private set; }
+        internal IEnumerable<IValueBuilder>? Values { get; private set; }
 
         public IReadOnlyList<IntermediateModifierEntry> Entries => throw new InvalidOperationException();
 
-        public StatConverter StatConverter { get; private set; }
-        public ValueConverter ValueConverter { get; private set; }
+        public StatConverter? StatConverter { get; private set; }
+        public ValueConverter? ValueConverter { get; private set; }
 
         public IModifierBuilder WithCondition(IConditionBuilder condition)
         {

--- a/PoESkillTree.Engine.Computation.Data.Tests/Collections/PropertyMatcherCollectionTest.cs
+++ b/PoESkillTree.Engine.Computation.Data.Tests/Collections/PropertyMatcherCollectionTest.cs
@@ -12,7 +12,9 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
     {
         private const string Regex = "regex";
 
+#pragma warning disable 8618 // Initialized in SetUp
         private PropertyMatcherCollection _sut;
+#pragma warning restore
 
         [SetUp]
         public void SetUp()
@@ -56,7 +58,7 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
 
             var builder = _sut.AssertSingle(Regex);
             Assert.That(builder.Stats, Has.Exactly(1).SameAs(stat));
-            var actualValue = builder.ValueConverter(inputValue);
+            var actualValue = builder.ValueConverter!(inputValue);
             Assert.AreEqual(expectedValue, actualValue);
         }
 

--- a/PoESkillTree.Engine.Computation.Data.Tests/Collections/StatManipulatorMatcherCollectionTest.cs
+++ b/PoESkillTree.Engine.Computation.Data.Tests/Collections/StatManipulatorMatcherCollectionTest.cs
@@ -27,7 +27,7 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
         [Test]
         public void AddWithoutSubstitution()
         {
-            StatConverter manipulator = s => null;
+            StatConverter manipulator = s => null!;
 
             _sut.Add(Regex, manipulator);
 
@@ -38,7 +38,7 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
         [Test]
         public void AddWithSubstitution()
         {
-            StatConverter manipulator = s => null;
+            StatConverter manipulator = s => null!;
 
             _sut.Add(Regex, manipulator, "substitution");
 

--- a/PoESkillTree.Engine.Computation.Data.Tests/Collections/StatManipulatorMatcherCollectionTest.cs
+++ b/PoESkillTree.Engine.Computation.Data.Tests/Collections/StatManipulatorMatcherCollectionTest.cs
@@ -8,7 +8,9 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
     {
         private const string Regex = "regex";
 
+#pragma warning disable 8618 // Initialized in SetUp
         private StatManipulatorMatcherCollection _sut;
+#pragma warning restore
 
         [SetUp]
         public void SetUp()

--- a/PoESkillTree.Engine.Computation.Data.Tests/Collections/StatMatcherCollectionTest.cs
+++ b/PoESkillTree.Engine.Computation.Data.Tests/Collections/StatMatcherCollectionTest.cs
@@ -11,7 +11,9 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
     {
         private const string Regex = "regex";
 
+#pragma warning disable 8618 // Initialized in SetUp
         private StatMatcherCollection<IStatBuilder> _sut;
+#pragma warning restore
 
         [SetUp]
         public void SetUp()

--- a/PoESkillTree.Engine.Computation.Data.Tests/Collections/StatReplacerCollectionTest.cs
+++ b/PoESkillTree.Engine.Computation.Data.Tests/Collections/StatReplacerCollectionTest.cs
@@ -6,26 +6,21 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
     [TestFixture]
     public class StatReplacerCollectionTest
     {
-        private StatReplacerCollection _sut;
-
-        [SetUp]
-        public void SetUp()
-        {
-            _sut = new StatReplacerCollection();
-        }
-
         [Test]
         public void IsEmpty()
         {
-            Assert.AreEqual(0, _sut.Count());
+            var sut = new StatReplacerCollection();
+
+            Assert.AreEqual(0, sut.Count());
         }
 
         [Test]
         public void AddAddsCorrectData()
         {
-            _sut.Add("originalStat", "r1", "r2", "r3");
+            var sut = new StatReplacerCollection {{"originalStat", "r1", "r2", "r3"}};
 
-            var data = _sut.Single();
+            var data = sut.Single();
+
             Assert.AreEqual("originalStat", data.OriginalStatRegex);
             CollectionAssert.AreEqual(new[] { "r1", "r2", "r3" }, data.Replacements);
         }
@@ -33,11 +28,9 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
         [Test]
         public void AddManyAddsToCount()
         {
-            _sut.Add("1");
-            _sut.Add("2", "r1");
-            _sut.Add("3", "r1", "r2");
+            var sut = new StatReplacerCollection {"1", {"2", "r1"}, {"3", "r1", "r2"}};
 
-            Assert.AreEqual(3, _sut.Count());
+            Assert.AreEqual(3, sut.Count());
         }
     }
 }

--- a/PoESkillTree.Engine.Computation.Data.Tests/Collections/ValueConversionMatcherCollectionTest.cs
+++ b/PoESkillTree.Engine.Computation.Data.Tests/Collections/ValueConversionMatcherCollectionTest.cs
@@ -11,18 +11,12 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
     {
         private const string Regex = "regex";
 
-        private ValueConversionMatcherCollection _sut;
-
-        [SetUp]
-        public void SetUp()
-        {
-            _sut = new ValueConversionMatcherCollection(new ModifierBuilderStub());
-        }
-
         [Test]
         public void IsEmpty()
         {
-            Assert.IsEmpty(_sut);
+            var sut = new ValueConversionMatcherCollection(new ModifierBuilderStub());
+
+            Assert.IsEmpty(sut);
         }
 
         [Test]
@@ -30,22 +24,25 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
         {
             var inputValue = new ValueBuilder(Mock.Of<IValueBuilder>());
             var expectedValue = new ValueBuilder(Mock.Of<IValueBuilder>());
+            var sut = new ValueConversionMatcherCollection(new ModifierBuilderStub())
+            {
+                {Regex, _ => expectedValue}
+            };
 
-            _sut.Add(Regex, _ => expectedValue);
-
-            var builder = _sut.AssertSingle(Regex);
-            var actualValue = builder.ValueConverter(inputValue);
+            var builder = sut.AssertSingle(Regex);
+            var actualValue = builder.ValueConverter!(inputValue);
             Assert.AreEqual(expectedValue, actualValue);
         }
 
         [Test]
         public void AddManyAddsToCount()
         {
-            _sut.Add(Regex, Funcs.Identity);
-            _sut.Add(Regex, Funcs.Identity);
-            _sut.Add(Regex, Funcs.Identity);
+            var sut = new ValueConversionMatcherCollection(new ModifierBuilderStub())
+            {
+                {Regex, Funcs.Identity}, {Regex, Funcs.Identity}, {Regex, Funcs.Identity}
+            };
 
-            Assert.AreEqual(3, _sut.Count());
+            Assert.AreEqual(3, sut.Count());
         }
     }
 }

--- a/PoESkillTree.Engine.Computation.Data.Tests/PoESkillTree.Engine.Computation.Data.Tests.csproj
+++ b/PoESkillTree.Engine.Computation.Data.Tests/PoESkillTree.Engine.Computation.Data.Tests.csproj
@@ -2,11 +2,13 @@
   <PropertyGroup>
     <RootNamespace>PoESkillTree.Engine.Computation.Data</RootNamespace>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8</LangVersion>
     <AssemblyTitle>PoESkillTree.Engine.Computation.Data.Tests</AssemblyTitle>
     <Product>PoESkillTree.Engine.Computation.Data.Tests</Product>
     <Copyright>Copyright ©  2017</Copyright>
     <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>8600;8601;8602;8603;8604;8619;8620</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/PoESkillTree.Engine.Computation.Data.Tests/PoESkillTree.Engine.Computation.Data.Tests.csproj
+++ b/PoESkillTree.Engine.Computation.Data.Tests/PoESkillTree.Engine.Computation.Data.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>PoESkillTree.Engine.Computation.Data</RootNamespace>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyTitle>PoESkillTree.Engine.Computation.Data.Tests</AssemblyTitle>
     <Product>PoESkillTree.Engine.Computation.Data.Tests</Product>

--- a/PoESkillTree.Engine.Computation.Data.Tests/PoESkillTree.Engine.Computation.Data.Tests.csproj
+++ b/PoESkillTree.Engine.Computation.Data.Tests/PoESkillTree.Engine.Computation.Data.Tests.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.12.0" />
+    <PackageReference Include="Moq" Version="4.13.0" />
     <PackageReference Include="morelinq" Version="3.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PoESkillTree.Engine.Utils\PoESkillTree.Engine.Utils.csproj" />

--- a/PoESkillTree.Engine.Computation.Data/Base/UsesStatBuilders.cs
+++ b/PoESkillTree.Engine.Computation.Data/Base/UsesStatBuilders.cs
@@ -61,7 +61,7 @@ namespace PoESkillTree.Engine.Computation.Data.Base
 
         protected IBuffBuilders Buff => BuilderFactories.BuffBuilders;
 
-        protected IBuffBuilderCollection Buffs(IEntityBuilder source = null, params IEntityBuilder[] targets) =>
+        protected IBuffBuilderCollection Buffs(IEntityBuilder? source = null, params IEntityBuilder[] targets) =>
             Buff.Buffs(source, targets);
 
         // Charges

--- a/PoESkillTree.Engine.Computation.Data/Collections/FormAndStatMatcherCollection.cs
+++ b/PoESkillTree.Engine.Computation.Data/Collections/FormAndStatMatcherCollection.cs
@@ -29,13 +29,13 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
         /// Adds a matcher with a form, value, stat and optionally a condition.
         /// </summary>
         public void Add([RegexPattern] string regex, IFormBuilder form, double value, IStatBuilder stat,
-            IConditionBuilder condition = null)
+            IConditionBuilder? condition = null)
         {
             Add(regex, form, _valueFactory.Create(value), stat, condition);
         }
 
         public void Add([RegexPattern] string regex, IFormBuilder form, IValueBuilder value, IStatBuilder stat,
-            IConditionBuilder condition = null)
+            IConditionBuilder? condition = null)
         {
             var builder = ModifierBuilder
                 .WithForm(form)

--- a/PoESkillTree.Engine.Computation.Data/Collections/GivenStatCollection.cs
+++ b/PoESkillTree.Engine.Computation.Data/Collections/GivenStatCollection.cs
@@ -29,10 +29,10 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        public void Add(IFormBuilder form, IStatBuilder stat, double value, IConditionBuilder condition = null)
+        public void Add(IFormBuilder form, IStatBuilder stat, double value, IConditionBuilder? condition = null)
             => Add(form, stat, _valueFactory.Create(value), condition);
 
-        public void Add(IFormBuilder form, IStatBuilder stat, IValueBuilder value, IConditionBuilder condition = null)
+        public void Add(IFormBuilder form, IStatBuilder stat, IValueBuilder value, IConditionBuilder? condition = null)
         {
             var builder = _modifierBuilder
                 .WithForm(form)

--- a/PoESkillTree.Engine.Computation.Data/Collections/ReferencedMatcherCollection.cs
+++ b/PoESkillTree.Engine.Computation.Data/Collections/ReferencedMatcherCollection.cs
@@ -13,6 +13,7 @@ namespace PoESkillTree.Engine.Computation.Data.Collections
     /// </summary>
     /// <typeparam name="T">The type of values of <see cref="ReferencedMatcherData.Match"/></typeparam>
     public class ReferencedMatcherCollection<T> : IReadOnlyList<ReferencedMatcherData>
+        where T : class
     {
         private readonly List<ReferencedMatcherData> _matchers = new List<ReferencedMatcherData>();
 

--- a/PoESkillTree.Engine.Computation.Data/PoESkillTree.Engine.Computation.Data.csproj
+++ b/PoESkillTree.Engine.Computation.Data/PoESkillTree.Engine.Computation.Data.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Version>1.0.0</Version>
     <FileVersion>1.0.0.0</FileVersion>

--- a/PoESkillTree.Engine.Computation.Data/PoESkillTree.Engine.Computation.Data.csproj
+++ b/PoESkillTree.Engine.Computation.Data/PoESkillTree.Engine.Computation.Data.csproj
@@ -34,6 +34,10 @@
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All" />
     <PackageReference Include="morelinq" Version="3.2.0" />
+    <PackageReference Include="Nullable" Version="1.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PoESkillTree.Engine.Utils\PoESkillTree.Engine.Utils.csproj" />

--- a/PoESkillTree.Engine.Computation.Data/PoESkillTree.Engine.Computation.Data.csproj
+++ b/PoESkillTree.Engine.Computation.Data/PoESkillTree.Engine.Computation.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8</LangVersion>
     <Version>1.0.0</Version>
     <FileVersion>1.0.0.0</FileVersion>
 
@@ -17,6 +17,11 @@
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSources>true</IncludeSources>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <WarningsAsErrors>8600;8601;8602;8603;8604;8613;8619;8620;8625</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="LibLog" Version="5.0.6">

--- a/PoESkillTree.Engine.Computation.IntegrationTests/CompositionRootTestBase.cs
+++ b/PoESkillTree.Engine.Computation.IntegrationTests/CompositionRootTestBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using NUnit.Framework;
 using PoESkillTree.Engine.Computation.Common.Builders;
 using PoESkillTree.Engine.Computation.Common.Data;
 using PoESkillTree.Engine.Computation.Data.Steps;
@@ -12,31 +11,23 @@ namespace PoESkillTree.Engine.Computation.IntegrationTests
 {
     public abstract class CompositionRootTestBase
     {
-        private static Lazy<GameData> _gameData;
-        private static Lazy<Task<IBuilderFactories>> _builderFactories;
-        private static Lazy<Task<IParsingData<ParsingStep>>> _parsingData;
-        private static Lazy<Task<IParser>> _parser;
+        private static readonly Lazy<GameData> LazyGameData = new Lazy<GameData>(
+            () => new GameData(PassiveTreeDefinition.CreateKeystoneDefinitions()));
 
-        protected static GameData GameData => _gameData.Value;
-        protected static Task<IBuilderFactories> BuilderFactoriesTask => _builderFactories.Value;
-        protected static Task<IParsingData<ParsingStep>> ParsingDataTask => _parsingData.Value;
-        protected static Task<IParser> ParserTask => _parser.Value;
+        private static readonly Lazy<Task<IBuilderFactories>> LazyBuilderFactories = new Lazy<Task<IBuilderFactories>>(
+            () => Builders.BuilderFactories.CreateAsync(LazyGameData.Value));
 
-        [OneTimeSetUp]
-        public static void CreateCompositionRoot()
-        {
-            if (_gameData is null)
-            {
-                _gameData = new Lazy<GameData>(
-                    () => new GameData(PassiveTreeDefinition.CreateKeystoneDefinitions()));
-                _builderFactories = new Lazy<Task<IBuilderFactories>>(
-                    () => Builders.BuilderFactories.CreateAsync(_gameData.Value));
-                _parsingData = new Lazy<Task<IParsingData<ParsingStep>>>(
-                    () => Data.ParsingData.CreateAsync(_gameData.Value, _builderFactories.Value));
-                _parser = new Lazy<Task<IParser>>(
-                    () => Parser<ParsingStep>.CreateAsync(_gameData.Value, _builderFactories.Value,
-                        _parsingData.Value));
-            }
-        }
+        private static readonly Lazy<Task<IParsingData<ParsingStep>>> LazyParsingData =
+            new Lazy<Task<IParsingData<ParsingStep>>>(
+                () => Data.ParsingData.CreateAsync(LazyGameData.Value, LazyBuilderFactories.Value));
+
+        private static readonly Lazy<Task<IParser>> LazyParser = new Lazy<Task<IParser>>(
+            () => Parser<ParsingStep>.CreateAsync(LazyGameData.Value, LazyBuilderFactories.Value,
+                LazyParsingData.Value));
+
+        protected static GameData GameData => LazyGameData.Value;
+        protected static Task<IBuilderFactories> BuilderFactoriesTask => LazyBuilderFactories.Value;
+        protected static Task<IParsingData<ParsingStep>> ParsingDataTask => LazyParsingData.Value;
+        protected static Task<IParser> ParserTask => LazyParser.Value;
     }
 }

--- a/PoESkillTree.Engine.Computation.IntegrationTests/Core/BasicCalculatorTest.cs
+++ b/PoESkillTree.Engine.Computation.IntegrationTests/Core/BasicCalculatorTest.cs
@@ -102,8 +102,8 @@ namespace PoESkillTree.Engine.Computation.IntegrationTests.Core
 
             sut.NewBatchUpdate()
                 .AddModifier(Stat, Form.BaseAdd, new Constant(value))
-                .AddModifier(Stat.Minimum, Form.BaseAdd, new Constant(10))
-                .AddModifier(Stat.Maximum, Form.BaseAdd, new Constant(20))
+                .AddModifier(Stat.Minimum!, Form.BaseAdd, new Constant(10))
+                .AddModifier(Stat.Maximum!, Form.BaseAdd, new Constant(20))
                 .DoUpdate();
             var expected = new NodeValue(Math.Max(Math.Min(value, 20), 10));
 

--- a/PoESkillTree.Engine.Computation.IntegrationTests/Core/BasicCalculatorTest.cs
+++ b/PoESkillTree.Engine.Computation.IntegrationTests/Core/BasicCalculatorTest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Linq;
 using NUnit.Framework;
 using PoESkillTree.Engine.Computation.Builders.Behaviors;
@@ -159,7 +158,7 @@ namespace PoESkillTree.Engine.Computation.IntegrationTests.Core
             var registeredStat =
                 new Stat("r", explicitRegistrationType: ExplicitRegistrationTypes.UserSpecifiedValue(0));
             var value = new StatValue(registeredStat);
-            IStat actual = null;
+            IStat? actual = null;
             sut.ExplicitlyRegisteredStats.CollectionChanged += (sender, args) =>
             {
                 Assert.IsNull(actual);

--- a/PoESkillTree.Engine.Computation.IntegrationTests/Core/ConversionTest.cs
+++ b/PoESkillTree.Engine.Computation.IntegrationTests/Core/ConversionTest.cs
@@ -11,6 +11,7 @@ namespace PoESkillTree.Engine.Computation.IntegrationTests.Core
         // This test tests the behaviors necessary for stat conversions
         // (located in PoESkillTree.Engine.Computation.Builders.Behaviors).
 
+#pragma warning disable 8618 // Initialized in SetUp
         private ICalculator _sut;
         private IStat _bar;
         private IStat _baz;
@@ -23,6 +24,7 @@ namespace PoESkillTree.Engine.Computation.IntegrationTests.Core
         private IStat _bazConversion;
         private IStat _bazSkillConversion;
         private IStat _barBazConversion;
+#pragma warning restore 8618
 
         [SetUp]
         public void SetUp()
@@ -58,7 +60,7 @@ namespace PoESkillTree.Engine.Computation.IntegrationTests.Core
         {
             _sut.NewBatchUpdate()
                 .AddModifier(_bar, Form.BaseAdd, 3)
-                .AddModifier(new[] { _barFooConversion, _barConversion, _barSkillConversion }, Form.BaseAdd, 100.0 / 3)
+                .AddModifier(new[] {_barFooConversion, _barConversion, _barSkillConversion}, Form.BaseAdd, 100.0 / 3)
                 .DoUpdate();
 
             Assert.AreEqual(new NodeValue(1), GetValue(_foo));
@@ -68,7 +70,7 @@ namespace PoESkillTree.Engine.Computation.IntegrationTests.Core
         [Test]
         public void ComplexSingleSource()
         {
-            var barFooConversion = new[] { _barFooConversion, _barConversion, _barSkillConversion };
+            var barFooConversion = new[] {_barFooConversion, _barConversion, _barSkillConversion};
             var localSource = new ModifierSource.Local.Given();
             var skillSource = new ModifierSource.Local.Skill("");
             _sut.NewBatchUpdate()
@@ -115,8 +117,8 @@ namespace PoESkillTree.Engine.Computation.IntegrationTests.Core
         [Test]
         public void ZeroChain()
         {
-            var barBazConversion = new[] { _barBazConversion, _barConversion, _barSkillConversion };
-            var bazFooConversion = new[] { _bazFooConversion, _bazConversion, _bazSkillConversion };
+            var barBazConversion = new[] {_barBazConversion, _barConversion, _barSkillConversion};
+            var bazFooConversion = new[] {_bazFooConversion, _bazConversion, _bazSkillConversion};
             _sut.NewBatchUpdate()
                 .AddModifier(_bar, Form.BaseAdd, 8)
                 .AddModifier(barBazConversion, Form.BaseAdd, 0)
@@ -131,8 +133,8 @@ namespace PoESkillTree.Engine.Computation.IntegrationTests.Core
         [Test]
         public void Chain()
         {
-            var barBazConversion = new[] { _barBazConversion, _barConversion, _barSkillConversion };
-            var bazFooConversion = new[] { _bazFooConversion, _bazConversion, _bazSkillConversion };
+            var barBazConversion = new[] {_barBazConversion, _barConversion, _barSkillConversion};
+            var bazFooConversion = new[] {_bazFooConversion, _bazConversion, _bazSkillConversion};
             _sut.NewBatchUpdate()
                 .AddModifier(_bar, Form.BaseAdd, 8)
                 .AddModifier(barBazConversion, Form.BaseAdd, 50)

--- a/PoESkillTree.Engine.Computation.IntegrationTests/ItemParserTest.cs
+++ b/PoESkillTree.Engine.Computation.IntegrationTests/ItemParserTest.cs
@@ -17,12 +17,14 @@ namespace PoESkillTree.Engine.Computation.IntegrationTests
     [TestFixture]
     public class ItemParserTest : CompositionRootTestBase
     {
+#pragma warning disable 8618 // Initialized in OneTimeSetUp and SetUpAsync
         private static Task<XmlUniqueList> _uniqueDefinitionsTask;
 
         private ModifierDefinitions _modifierDefinitions;
         private BaseItemDefinitions _baseItemDefinitions;
         private IStatTranslator _statTranslator;
         private IParser _parser;
+#pragma warning restore 8618
 
         [OneTimeSetUp]
         public static void OneTimeSetUp()
@@ -126,7 +128,7 @@ namespace PoESkillTree.Engine.Computation.IntegrationTests
                     ("CriticalStrike.BaseChance.Attack.MainHand.Skill", Form.BaseSet,
                         definition.Properties[1].Value / 100D, local),
                     ("MainHand.Range.Attack.MainHand.Skill", Form.BaseSet, definition.Properties[4].Value, local),
-                    ("base phys", default, null, null),
+                    ("base phys", default, null, local),
                     ("MainHand.Physical.Damage.Attack.MainHand.Skill", Form.Increase, 20, local),
                     ("MainHand.Level.Required", Form.BaseSet, 58, local),
                     ("MainHand.Dexterity.Required", Form.BaseSet, definition.Requirements.Dexterity, local),

--- a/PoESkillTree.Engine.Computation.IntegrationTests/JewelParserTest.cs
+++ b/PoESkillTree.Engine.Computation.IntegrationTests/JewelParserTest.cs
@@ -16,11 +16,13 @@ namespace PoESkillTree.Engine.Computation.IntegrationTests
     [TestFixture]
     public class JewelParserTest : CompositionRootTestBase
     {
+#pragma warning disable 8618 // Initialized in OneTimeSetUp and SetUpAsync
         private static Task<XmlUniqueList> _uniqueDefinitionsTask;
 
         private ModifierDefinitions _modifierDefinitions;
         private IStatTranslator _statTranslator;
         private IParser _parser;
+#pragma warning restore 8618
 
         [OneTimeSetUp]
         public static void OneTimeSetUp()

--- a/PoESkillTree.Engine.Computation.IntegrationTests/MechanicsTest.cs
+++ b/PoESkillTree.Engine.Computation.IntegrationTests/MechanicsTest.cs
@@ -18,9 +18,11 @@ namespace PoESkillTree.Engine.Computation.IntegrationTests
     [TestFixture]
     public class MechanicsTest : CompositionRootTestBase
     {
+#pragma warning disable 8618 // Initialized in ClassInit
         private static IReadOnlyList<Modifier> _givenMods;
         private static IBuilderFactories _builderFactories;
         private static IMetaStatBuilders _metaStats;
+#pragma warning restore 8618
 
         private const double Accuracy = (-2 + 2 * 90) + 1000;
         private const double EffectiveDamageMultiplierWithNonCrits = 0.4 * 1.2 * 1.75;

--- a/PoESkillTree.Engine.Computation.IntegrationTests/ParsingTest.cs
+++ b/PoESkillTree.Engine.Computation.IntegrationTests/ParsingTest.cs
@@ -50,7 +50,7 @@ namespace PoESkillTree.Engine.Computation.IntegrationTests
 
         private static IEnumerable<string> ReadParseableStatLines()
         {
-            var unparsedGivenStats = new GivenStatsCollection(null, null, null).SelectMany(s => s.GivenStatLines);
+            var unparsedGivenStats = new GivenStatsCollection(null!, null!, null!).SelectMany(s => s.GivenStatLines);
             return ReadDataLines("SkillTreeStatLines")
                 .Concat(ReadDataLines("ItemAffixes"))
                 .Concat(ReadDataLines("ParseableStatLines"))

--- a/PoESkillTree.Engine.Computation.IntegrationTests/ParsingTest.cs
+++ b/PoESkillTree.Engine.Computation.IntegrationTests/ParsingTest.cs
@@ -20,8 +20,10 @@ namespace PoESkillTree.Engine.Computation.IntegrationTests
     [TestFixture]
     public class ParsingTest : CompositionRootTestBase
     {
+#pragma warning disable 8618 // Initialized in SetUpAsync
         private IParser _parser;
         private IBuilderFactories _f;
+#pragma warning restore 8618
 
         [SetUp]
         public async Task SetUpAsync()

--- a/PoESkillTree.Engine.Computation.IntegrationTests/ParsingTestUtils.cs
+++ b/PoESkillTree.Engine.Computation.IntegrationTests/ParsingTestUtils.cs
@@ -14,7 +14,7 @@ namespace PoESkillTree.Engine.Computation.IntegrationTests
     public static class ParsingTestUtils
     {
         public static void AssertIsParsedSuccessfully(
-            ParseResult parseResult, IEnumerable<string> ignoredStatLines = null)
+            ParseResult parseResult, IEnumerable<string>? ignoredStatLines = null)
         {
             var (failedLines, remaining, result) = parseResult;
 

--- a/PoESkillTree.Engine.Computation.IntegrationTests/PoESkillTree.Engine.Computation.IntegrationTests.csproj
+++ b/PoESkillTree.Engine.Computation.IntegrationTests/PoESkillTree.Engine.Computation.IntegrationTests.csproj
@@ -13,15 +13,15 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="NLog" Version="4.6.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="NLog" Version="4.6.7" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.12.0" />
+    <PackageReference Include="Moq" Version="4.13.0" />
     <PackageReference Include="morelinq" Version="3.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/PoESkillTree.Engine.Computation.IntegrationTests/PoESkillTree.Engine.Computation.IntegrationTests.csproj
+++ b/PoESkillTree.Engine.Computation.IntegrationTests/PoESkillTree.Engine.Computation.IntegrationTests.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyTitle>PoESkillTree.Engine.Computation.IntegrationTests</AssemblyTitle>
     <Product>PoESkillTree.Engine.Computation.IntegrationTests</Product>

--- a/PoESkillTree.Engine.Computation.IntegrationTests/PoESkillTree.Engine.Computation.IntegrationTests.csproj
+++ b/PoESkillTree.Engine.Computation.IntegrationTests/PoESkillTree.Engine.Computation.IntegrationTests.csproj
@@ -1,11 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8</LangVersion>
     <AssemblyTitle>PoESkillTree.Engine.Computation.IntegrationTests</AssemblyTitle>
     <Product>PoESkillTree.Engine.Computation.IntegrationTests</Product>
     <Copyright>Copyright ©  2017</Copyright>
     <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>8600;8601;8602;8603;8604;8619;8620</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/PoESkillTree.Engine.Computation.IntegrationTests/SkillParserTest.cs
+++ b/PoESkillTree.Engine.Computation.IntegrationTests/SkillParserTest.cs
@@ -19,8 +19,10 @@ namespace PoESkillTree.Engine.Computation.IntegrationTests
     [TestFixture]
     public class SkillParserTest : CompositionRootTestBase
     {
+#pragma warning disable 8618 // Initialized in ClassInit
         private SkillDefinitions _skillDefinitions;
         private IParser _parser;
+#pragma warning restore 8618
 
         [SetUp]
         public async Task SetUpAsync()

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/ItemParsers/ItemParserTest.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/ItemParsers/ItemParserTest.cs
@@ -439,9 +439,10 @@ namespace PoESkillTree.Engine.Computation.Parsing.ItemParsers
         }
 
         private static ItemParser CreateSut(
-            BaseItemDefinition baseItemDefinition, ICoreParser coreParser = null, IStatTranslator statTranslator = null)
+            BaseItemDefinition baseItemDefinition, ICoreParser? coreParser = null, IStatTranslator? statTranslator = null)
         {
-            coreParser = coreParser ?? Mock.Of<ICoreParser>();
+            coreParser ??= Mock.Of<ICoreParser>();
+            statTranslator ??= Mock.Of<IStatTranslator>();
 
             var baseItemDefinitions = new BaseItemDefinitions(new[] { baseItemDefinition });
             return new ItemParser(baseItemDefinitions, CreateBuilderFactories(), coreParser, statTranslator);
@@ -470,8 +471,8 @@ namespace PoESkillTree.Engine.Computation.Parsing.ItemParsers
         }
 
         private static BaseItemDefinition CreateBaseItemDefinition(Item item, ItemClass itemClass, Tags tags = default,
-            IReadOnlyList<Property> properties = null,
-            IReadOnlyList<UntranslatedStat> buffStats = null, Requirements requirements = null)
+            IReadOnlyList<Property>? properties = null,
+            IReadOnlyList<UntranslatedStat>? buffStats = null, Requirements? requirements = null)
             => new BaseItemDefinition(item.BaseMetadataId, "", itemClass, new string[0], tags,
                 properties ?? new Property[0],
                 buffStats ?? new UntranslatedStat[0],

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/ItemParsers/ItemParserTest.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/ItemParsers/ItemParserTest.cs
@@ -285,8 +285,8 @@ namespace PoESkillTree.Engine.Computation.Parsing.ItemParsers
             var result = sut.Parse(parserParam);
 
             var actual = GetFirstModifierWithIdentity(result.Modifiers, expected.Stats[0].Identity);
-            var expectedValue = expected.Value.Calculate(null);
-            Assert.AreEqual(expectedValue, actual.Value.Calculate(null));
+            var expectedValue = expected.Value.Calculate(null!);
+            Assert.AreEqual(expectedValue, actual.Value.Calculate(null!));
         }
 
         [TestCase("armour", "Armour")]
@@ -351,7 +351,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.ItemParsers
             {
                 CreateModifier($"BaseCastTime.{statSuffix}", Form.BaseSet, 1, source),
                 CreateModifier($"{slot}.CastRate.{statSuffix}", Form.BaseSet, 
-                    new FunctionalValue(null, $"1 / Character.BaseCastTime.{statSuffix}.Value(Total, Global)"), source),
+                    new FunctionalValue(null!, $"1 / Character.BaseCastTime.{statSuffix}.Value(Total, Global)"), source),
                 CreateModifier($"CastRate.{statSuffix}", Form.BaseSet,
                     new StatValue(new Stat($"{slot}.CastRate.{statSuffix}")), source),
             };
@@ -378,7 +378,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.ItemParsers
             var expected = new[]
             {
                 CreateModifier($"{slot}.{stat}", Form.BaseSet,
-                    new FunctionalValue(null, "Value(min: 2, max: 8)"), source),
+                    new FunctionalValue(null!, "Value(min: 2, max: 8)"), source),
                 CreateModifier($"{stat}", Form.BaseSet, new StatValue(new Stat($"{slot}.{stat}")), source),
             };
             var sut = CreateSut(baseItemDefinition);
@@ -477,7 +477,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.ItemParsers
                 properties ?? new Property[0],
                 buffStats ?? new UntranslatedStat[0],
                 requirements ?? new Requirements(0, 0, 0, 0),
-                null, 0, 0, 0, default, "");
+                new CraftableStat[0], 0, 0, 0, default, "");
 
         private static ModifierSource.Global CreateGlobalSource(ItemParserParameter parserParam)
             => new ModifierSource.Global(CreateLocalSource(parserParam));

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/JewelParsers/CompositeTransformationJewelParserTest.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/JewelParsers/CompositeTransformationJewelParserTest.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using PoESkillTree.Engine.Computation.Common.Builders.Values;
 using PoESkillTree.Engine.GameModel.PassiveTree;
 
 namespace PoESkillTree.Engine.Computation.Parsing.JewelParsers
@@ -44,7 +45,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.JewelParsers
         [Test]
         public void TransformationResultIsThatOfMatchingComponentGivenAComponentMatches()
         {
-            var expected = new[] { new TransformedNodeModifier("", null), };
+            var expected = new[] { new TransformedNodeModifier("", Mock.Of<IValueBuilder>()), };
             var nodesInRadius = new PassiveNodeDefinition[0];
             var component = Mock.Of<ITransformationJewelParser>(p => 
                 p.IsTransformationJewelModifier(JewelModifier) &&

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/JewelParsers/JewelInItemParserTest.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/JewelParsers/JewelInItemParserTest.cs
@@ -40,7 +40,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.JewelParsers
             result.Modifiers.Should().BeEmpty();
         }
 
-        private static JewelInItemParser CreateSut(ICoreParser coreParser = null)
+        private static JewelInItemParser CreateSut(ICoreParser? coreParser = null)
             => new JewelInItemParser(coreParser ?? Mock.Of<ICoreParser>());
 
         private static ItemParserParameter CreateItem(ItemSlot itemSlot, params string[] mods)

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/JewelParsers/JewelInSkillTreeParserTest.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/JewelParsers/JewelInSkillTreeParserTest.cs
@@ -40,7 +40,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.JewelParsers
             result.Modifiers.Should().BeEmpty();
         }
 
-        private static JewelInSkillTreeParser CreateSut(ICoreParser coreParser = null)
+        private static JewelInSkillTreeParser CreateSut(ICoreParser? coreParser = null)
             => new JewelInSkillTreeParser(
                 new PassiveTreeDefinition(new[] { CreateNode(0) }),
                 CreateBuilderFactories(),

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/JewelParsers/TransformationJewelParserTest.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/JewelParsers/TransformationJewelParserTest.cs
@@ -187,7 +187,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.JewelParsers
         private const string LioneyesFallModifier =
             "Melee and Melee Weapon Type modifiers in Radius are Transformed to Bow Modifiers";
 
-        private static TransformationJewelParser CreateSut(TransformationJewelParserData data = null)
+        private static TransformationJewelParser CreateSut(TransformationJewelParserData? data = null)
             => new TransformationJewelParser(
                 id => new ValueBuilderStub(id), 
                 data ?? new TransformationJewelParserData.SingleDamageTypeTransformation());

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/JewelParsers/TransformationJewelParserTest.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/JewelParsers/TransformationJewelParserTest.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.Linq;
-using FluentAssertions;
-using Moq;
+﻿using FluentAssertions;
 using NUnit.Framework;
 using PoESkillTree.Engine.Computation.Common;
-using PoESkillTree.Engine.Computation.Common.Builders.Conditions;
 using PoESkillTree.Engine.Computation.Common.Builders.Values;
 using PoESkillTree.Engine.GameModel.PassiveTree;
-using static PoESkillTree.Engine.Computation.Common.Helper;
 
 namespace PoESkillTree.Engine.Computation.Parsing.JewelParsers
 {
@@ -193,10 +188,10 @@ namespace PoESkillTree.Engine.Computation.Parsing.JewelParsers
                 data ?? new TransformationJewelParserData.SingleDamageTypeTransformation());
 
         private static NodeValue? BuildAndCalculate(IValueBuilder valueBuilder)
-            => valueBuilder.Build(default).Calculate(default);
+            => valueBuilder.Build(default).Calculate(default!);
 
         private static PassiveNodeDefinition CreateNode(ushort id, params string[] modifiers)
-            => new PassiveNodeDefinition(id, default, default, default,
+            => new PassiveNodeDefinition(id, default, "", default,
                 default, default, default, modifiers);
     }
 }

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/ParserTestUtils.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/ParserTestUtils.cs
@@ -31,13 +31,13 @@ namespace PoESkillTree.Engine.Computation.Parsing
             this IEnumerable<IValue> @this, IValueCalculationContext context)
             => @this.Select(v => v.Calculate(context));
 
-        public static Modifier CreateModifier(string stat, Form form, double value, ModifierSource source = null)
+        public static Modifier CreateModifier(string stat, Form form, double value, ModifierSource? source = null)
             => CreateModifier(stat, form, new NodeValue(value), source);
 
-        public static Modifier CreateModifier(string stat, Form form, NodeValue? value, ModifierSource source = null)
+        public static Modifier CreateModifier(string stat, Form form, NodeValue? value, ModifierSource? source = null)
             => CreateModifier(stat, form, new Constant(value), source);
 
-        public static Modifier CreateModifier(string stat, Form form, IValue value, ModifierSource source = null)
+        public static Modifier CreateModifier(string stat, Form form, IValue value, ModifierSource? source = null)
             => new Modifier(new[] { new Stat(stat), }, form, value, source ?? new ModifierSource.Global());
 
         public static BuilderFactories CreateBuilderFactories(params SkillDefinition[] skillDefinitions)

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/PassiveTreeParsers/PassiveNodeParserTest.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/PassiveTreeParsers/PassiveNodeParserTest.cs
@@ -141,9 +141,9 @@ namespace PoESkillTree.Engine.Computation.Parsing.PassiveTreeParsers
             Assert.That(result.Modifiers, Has.Member(expected));
         }
 
-        private static PassiveNodeParser CreateSut(PassiveNodeDefinition nodeDefinition, ICoreParser coreParser = null)
+        private static PassiveNodeParser CreateSut(PassiveNodeDefinition nodeDefinition, ICoreParser? coreParser = null)
         {
-            coreParser = coreParser ?? Mock.Of<ICoreParser>();
+            coreParser ??= Mock.Of<ICoreParser>();
             var treeDefinition = new PassiveTreeDefinition(new[] { nodeDefinition });
             return new PassiveNodeParser(treeDefinition, CreateBuilderFactories(), coreParser);
         }

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/PassiveTreeParsers/PassiveNodeParserTest.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/PassiveTreeParsers/PassiveNodeParserTest.cs
@@ -158,7 +158,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.PassiveTreeParsers
 
         private static Modifier CreateSkilledConditionalModifier(
             PassiveNodeDefinition nodeDefinition, string stat, Form form, double value)
-            => CreateModifier(stat, form, new FunctionalValue(null,
+            => CreateModifier(stat, form, new FunctionalValue(null!,
                     $"Character.{nodeDefinition.Id}.Skilled.Value(Total, Global).IsSet ? {value} : null"),
                 CreateGlobalSource(nodeDefinition));
 
@@ -168,7 +168,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.PassiveTreeParsers
 
         private static Modifier CreateEffectivenessMultipliedModifier(
             PassiveNodeDefinition nodeDefinition, string stat, Form form, string value)
-            => CreateModifier(stat, form, new FunctionalValue(null,
+            => CreateModifier(stat, form, new FunctionalValue(null!,
                     $"Character.{nodeDefinition.Id}.Effectiveness.Value(Total, Global) * {value}"),
                 CreateGlobalSource(nodeDefinition));
 

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/PoESkillTree.Engine.Computation.Parsing.Tests.csproj
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/PoESkillTree.Engine.Computation.Parsing.Tests.csproj
@@ -1,12 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>PoESkillTree.Engine.Computation.Parsing</RootNamespace>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8</LangVersion>
     <AssemblyTitle>PoESkillTree.Engine.Computation.Parsing.Tests</AssemblyTitle>
     <Product>PoESkillTree.Engine.Computation.Parsing.Tests</Product>
     <Copyright>Copyright ©  2017</Copyright>
     <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>8600;8601;8602;8603;8604;8619;8620</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/PoESkillTree.Engine.Computation.Parsing.Tests.csproj
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/PoESkillTree.Engine.Computation.Parsing.Tests.csproj
@@ -10,14 +10,14 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.7.0" />
-    <PackageReference Include="Moq" Version="4.12.0" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="Moq" Version="4.13.0" />
     <PackageReference Include="morelinq" Version="3.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PoESkillTree.Engine.Computation.Builders\PoESkillTree.Engine.Computation.Builders.csproj" />

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/PoESkillTree.Engine.Computation.Parsing.Tests.csproj
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/PoESkillTree.Engine.Computation.Parsing.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>PoESkillTree.Engine.Computation.Parsing</RootNamespace>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyTitle>PoESkillTree.Engine.Computation.Parsing.Tests</AssemblyTitle>
     <Product>PoESkillTree.Engine.Computation.Parsing.Tests</Product>

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/Referencing/MatcherMocks.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/Referencing/MatcherMocks.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Moq;
+using PoESkillTree.Engine.Computation.Common.Builders.Modifiers;
 using PoESkillTree.Engine.Computation.Common.Data;
 
 namespace PoESkillTree.Engine.Computation.Parsing.Referencing
@@ -17,7 +18,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.Referencing
         internal static IReferencedMatchers MockReferencedMatchers(string referenceName,
             params string[] patterns)
         {
-            var data = patterns.Select(p => new ReferencedMatcherData(p, null)).ToList();
+            var data = patterns.Select(p => new ReferencedMatcherData(p, "")).ToList();
             return Mock.Of<IReferencedMatchers>(m =>
                 m.ReferenceName == referenceName &&
                 m.Data == data);
@@ -35,7 +36,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.Referencing
         internal static IStatMatchers MockStatMatchers(IReadOnlyList<string> referenceNames,
             params string[] patterns)
         {
-            var data = patterns.Select(p => new MatcherData(p, null)).ToList();
+            var data = patterns.Select(p => new MatcherData(p, SimpleIntermediateModifier.Empty)).ToList();
             return Mock.Of<IStatMatchers>(m =>
                 m.ReferenceNames == referenceNames &&
                 m.Data == data);

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/Referencing/ReferenceServiceTest.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/Referencing/ReferenceServiceTest.cs
@@ -45,7 +45,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.Referencing
         [TestCase("Matchers1", 2, ExpectedResult = null)]
         [TestCase("Matchers2", 2, ExpectedResult = "3")]
         [TestCase("SMatchers1", 1, ExpectedResult = null)]
-        public string TryGetReferencedMatcherDataOutputsCorrectMatcherData(string referenceName, int matcherIndex)
+        public string? TryGetReferencedMatcherDataOutputsCorrectMatcherData(string referenceName, int matcherIndex)
         {
             var sut = new ReferenceService(DefaultReferencedMatchersList, DefaultStatMatchersList);
 
@@ -69,7 +69,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.Referencing
         [TestCase("SMatchers1", 4, ExpectedResult = null)]
         [TestCase("SMatchers2", 0, ExpectedResult = "1")]
         [TestCase("Matchers1", 1, ExpectedResult = null)]
-        public string TryGetMatcherDataOutputsCorrectMatcherData(string referenceName, int matcherIndex)
+        public string? TryGetMatcherDataOutputsCorrectMatcherData(string referenceName, int matcherIndex)
         {
             var sut = new ReferenceService(DefaultReferencedMatchersList, DefaultStatMatchersList);
 

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/Referencing/RegexGroupServiceFactoryTest.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/Referencing/RegexGroupServiceFactoryTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using Moq;
 using NUnit.Framework;
+using PoESkillTree.Engine.Computation.Common.Builders.Values;
 using PoESkillTree.Engine.Computation.Common.Parsing;
 
 namespace PoESkillTree.Engine.Computation.Parsing.Referencing
@@ -80,6 +82,6 @@ namespace PoESkillTree.Engine.Computation.Parsing.Referencing
             Assert.Throws<ArgumentException>(() => sut.CreateReferenceGroup("id", "", 0, "inner"));
         }
 
-        private static IRegexGroupFactory CreateSut() => new RegexGroupService(null);
+        private static IRegexGroupFactory CreateSut() => new RegexGroupService(Mock.Of<IValueBuilders>());
     }
 }

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/Referencing/RegexGroupServiceParserTest.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/Referencing/RegexGroupServiceParserTest.cs
@@ -147,7 +147,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.Referencing
             return new RegexGroupService(valueBuildersMock.Object);
         }
 
-        private static string[] ParseValues(
+        private static string?[] ParseValues(
             IReadOnlyDictionary<string, string> groups, string groupPrefix = "")
             => CreateParser()
                 .ParseValues(groups, groupPrefix)

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/Referencing/StatMatcherRegexExpanderTest.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/Referencing/StatMatcherRegexExpanderTest.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
+using PoESkillTree.Engine.Computation.Common.Builders.Values;
 
 namespace PoESkillTree.Engine.Computation.Parsing.Referencing
 {
@@ -79,6 +80,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.Referencing
 
         private static StatMatcherRegexExpander CreateSut(
             IReferencedRegexes referencedRegexe, bool matchesWholeLineOnly)
-            => new StatMatcherRegexExpander(referencedRegexe, new RegexGroupService(null), matchesWholeLineOnly);
+            => new StatMatcherRegexExpander(referencedRegexe,
+                new RegexGroupService(Mock.Of<IValueBuilders>()), matchesWholeLineOnly);
     }
 }

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/SkillParsers/ActiveSkillParserTest.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/SkillParsers/ActiveSkillParserTest.cs
@@ -655,7 +655,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
             var result = sut.Parse(skill);
 
             var modifier = GetFirstModifierWithIdentity(result.Modifiers, "Belt.0.Cost");
-            var actualValue = modifier.Value.Calculate(null);
+            var actualValue = modifier.Value.Calculate(null!);
             Assert.AreEqual(new NodeValue(10), actualValue);
         }
 
@@ -722,9 +722,9 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
             var result = sut.Parse(skill);
 
             var modifier = GetFirstModifierWithIdentity(result.Modifiers, "Clarity.ActiveSkillItemSlot");
-            Assert.AreEqual(new NodeValue((double) skill.ItemSlot), modifier.Value.Calculate(null));
+            Assert.AreEqual(new NodeValue((double) skill.ItemSlot), modifier.Value.Calculate(null!));
             modifier = GetFirstModifierWithIdentity(result.Modifiers, "Clarity.ActiveSkillSocketIndex");
-            Assert.AreEqual(new NodeValue(skill.SocketIndex), modifier.Value.Calculate(null));
+            Assert.AreEqual(new NodeValue(skill.SocketIndex), modifier.Value.Calculate(null!));
         }
 
         [TestCase(true)]

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/SkillParsers/SkillParserTestUtils.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/SkillParsers/SkillParserTestUtils.cs
@@ -21,7 +21,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
 
         public static ActiveSkillDefinition CreateActiveSkillDefinition(
             string displayName, IEnumerable<string> activeSkillTypes, IReadOnlyList<Keyword> keywords,
-            bool providesBuff = false, IReadOnlyList<ItemClass> weaponRestrictions = null)
+            bool providesBuff = false, IReadOnlyList<ItemClass>? weaponRestrictions = null)
             => CreateActiveSkillDefinition(displayName, null, activeSkillTypes, keywords,
                 providesBuff: providesBuff, weaponRestrictions: weaponRestrictions);
 
@@ -30,12 +30,12 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
             int? attackSpeedMultiplier = null,
             int? manaCost = null, double? manaMultiplier = null, int? manaCostOverride = null, int? cooldown = null,
             int requiredLevel = 0, int requiredDexterity = 0, int requiredIntelligence = 0, int requiredStrength = 0,
-            IReadOnlyList<UntranslatedStat> qualityStats = null, IReadOnlyList<UntranslatedStat> stats = null,
-            IReadOnlyList<IReadOnlyList<UntranslatedStat>> additionalStatsPerPart = null,
-            IReadOnlyList<BuffStat> qualityBuffStats = null, IReadOnlyList<BuffStat> buffStats = null,
-            IReadOnlyList<UntranslatedStat> qualityPassiveStats = null,
-            IReadOnlyList<UntranslatedStat> passiveStats = null,
-            SkillTooltipDefinition tooltip = null)
+            IReadOnlyList<UntranslatedStat>? qualityStats = null, IReadOnlyList<UntranslatedStat>? stats = null,
+            IReadOnlyList<IReadOnlyList<UntranslatedStat>>? additionalStatsPerPart = null,
+            IReadOnlyList<BuffStat>? qualityBuffStats = null, IReadOnlyList<BuffStat>? buffStats = null,
+            IReadOnlyList<UntranslatedStat>? qualityPassiveStats = null,
+            IReadOnlyList<UntranslatedStat>? passiveStats = null,
+            SkillTooltipDefinition? tooltip = null)
             => new SkillLevelDefinition(damageEffectiveness, damageMultiplier, criticalStrikeChance,
                 attackSpeedMultiplier, manaCost,
                 manaMultiplier, manaCostOverride, cooldown, requiredLevel, requiredDexterity, requiredIntelligence,
@@ -45,20 +45,20 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
                 passiveStats ?? new UntranslatedStat[0], tooltip ?? null);
 
         public static ActiveSkillDefinition CreateActiveSkillDefinition(
-            string displayName, int? castTime = null, IEnumerable<string> activeSkillTypes = null,
-            IReadOnlyList<Keyword> keywords = null, IReadOnlyList<IReadOnlyList<Keyword>> keywordsPerPart = null,
+            string displayName, int? castTime = null, IEnumerable<string>? activeSkillTypes = null,
+            IReadOnlyList<Keyword>? keywords = null, IReadOnlyList<IReadOnlyList<Keyword>>? keywordsPerPart = null,
             bool providesBuff = false, double? totemLifeMultiplier = null,
-            IReadOnlyList<ItemClass> weaponRestrictions = null)
+            IReadOnlyList<ItemClass>? weaponRestrictions = null)
         {
-            keywords = keywords ?? new Keyword[0];
+            keywords ??= new Keyword[0];
             return new ActiveSkillDefinition(displayName, castTime ?? 0, activeSkillTypes ?? new string[0],
                 new string[0], keywords, keywordsPerPart ?? new[] { keywords }, providesBuff, totemLifeMultiplier,
                 weaponRestrictions ?? new ItemClass[0]);
         }
 
         public static SupportSkillDefinition CreateSupportSkillDefinition(
-            IEnumerable<string> allowedActiveSkillTypes = null, IEnumerable<string> addedActiveSkillTypes = null,
-            IReadOnlyList<Keyword> addedKeywords = null)
+            IEnumerable<string>? allowedActiveSkillTypes = null, IEnumerable<string>? addedActiveSkillTypes = null,
+            IReadOnlyList<Keyword>? addedKeywords = null)
             => new SupportSkillDefinition(false,
                 allowedActiveSkillTypes ?? new string[0], new string[0], 
                 addedActiveSkillTypes ?? new string[0], addedKeywords ?? new Keyword[0]);

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/SkillParsers/SkillParserTestUtils.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/SkillParsers/SkillParserTestUtils.cs
@@ -42,7 +42,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
                 requiredStrength, qualityStats ?? new UntranslatedStat[0], stats ?? new UntranslatedStat[0],
                 additionalStatsPerPart ?? new[] { new UntranslatedStat[0]}, qualityBuffStats ?? new BuffStat[0],
                 buffStats ?? new BuffStat[0], qualityPassiveStats ?? new UntranslatedStat[0],
-                passiveStats ?? new UntranslatedStat[0], tooltip ?? null);
+                passiveStats ?? new UntranslatedStat[0], tooltip!);
 
         public static ActiveSkillDefinition CreateActiveSkillDefinition(
             string displayName, int? castTime = null, IEnumerable<string>? activeSkillTypes = null,

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/SkillParsers/SupportSkillParserTest.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/SkillParsers/SupportSkillParserTest.cs
@@ -44,7 +44,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
 
             var modifier = GetFirstModifierWithIdentity(result.Modifiers, "Belt.0.Cost");
             Assert.AreEqual(Form.TotalOverride, modifier.Form);
-            Assert.AreEqual(new NodeValue(42), modifier.Value.Calculate(null));
+            Assert.AreEqual(new NodeValue(42), modifier.Value.Calculate(null!));
         }
 
         [Test]
@@ -58,7 +58,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
 
             var modifier = GetFirstModifierWithIdentity(result.Modifiers,
                 $"Belt.0.Type.{ActiveSkillType.ManaCostIsReservation}");
-            Assert.AreEqual(new NodeValue(1), modifier.Value.Calculate(null));
+            Assert.AreEqual(new NodeValue(1), modifier.Value.Calculate(null!));
         }
 
         [TestCase(true)]

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/StringParsers/CachingParserTest.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/StringParsers/CachingParserTest.cs
@@ -13,8 +13,10 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
         private const string FalseRemaining = "falseRemaining";
         private const string FalseParsed = "falseParsed";
 
+#pragma warning disable 8618 // Initialized in SetUp
         private Mock<IStringParser<string>> _innerMock;
         private IStringParser<string> _inner;
+#pragma warning restore
 
         [SetUp]
         public void SetUp()
@@ -36,9 +38,9 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
         [Test]
         public void IsIParserInt()
         {
-            var sut = new CachingStringParser<int>(Mock.Of<IStringParser<int>>());
+            var sut = new CachingStringParser<string>(Mock.Of<IStringParser<string>>());
 
-            Assert.IsInstanceOf<IStringParser<int>>(sut);
+            Assert.IsInstanceOf<IStringParser<string>>(sut);
         }
 
         [TestCase(TrueStat, ExpectedResult = true)]
@@ -63,7 +65,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
         }
 
         [TestCase(TrueStat, ExpectedResult = TrueParsed)]
-        public string TryParsePassesResult(string stat)
+        public string? TryParsePassesResult(string stat)
         {
             var sut = new CachingStringParser<string>(_inner);
 

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/StringParsers/MatcherDataParserTest.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/StringParsers/MatcherDataParserTest.cs
@@ -54,7 +54,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
 
             var (_, _, result) = sut.Parse(stat);
 
-            var actual = result.Modifier;
+            var actual = result!.Modifier;
             Assert.AreEqual(expected, actual);
         }
 
@@ -72,7 +72,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
 
             var (_, _, result) = sut.Parse(stat);
 
-            var actual = result.RegexGroups;
+            var actual = result!.RegexGroups;
             CollectionAssert.AreEqual(expected, actual);
         }
 
@@ -86,7 +86,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
 
             var (_, _, result) = sut.Parse(stat);
 
-            var actual = result.RegexGroups;
+            var actual = result!.RegexGroups;
             Assert.That(actual, Has.Exactly(1).Items.EqualTo(new KeyValuePair<string, string>("0", fullGroup)));
         }
 

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/StringParsers/StatNormalizingParserTest.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/StringParsers/StatNormalizingParserTest.cs
@@ -8,7 +8,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
         [Test]
         public void IsIParser()
         {
-            var sut = new StatNormalizingParser<string>(null);
+            var sut = new StatNormalizingParser<string>(null!);
 
             Assert.IsInstanceOf<IStringParser<string>>(sut);
         }
@@ -17,7 +17,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
         [TestCase(false, ExpectedResult = false)]
         public bool TryParsePassesSuccessfullyParsed(bool innerSuccess)
         {
-            var inner = StringParserTestUtils.MockParser("stat", innerSuccess, default, "").Object;
+            var inner = StringParserTestUtils.MockParser("stat", innerSuccess, "", "").Object;
             var sut = new StatNormalizingParser<string>(inner);
 
             var (actual, _, _) = sut.Parse("stat");
@@ -41,7 +41,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
         public void TryParsePassesResul()
         {
             const string expected = "result";
-            var inner = StringParserTestUtils.MockParser("stat", default, default, expected).Object;
+            var inner = StringParserTestUtils.MockParser("stat", default, "", expected).Object;
             var sut = new StatNormalizingParser<string>(inner);
 
             var (_, _, actual) = sut.Parse("stat");

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/StringParsers/StatReplacingParserTest.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/StringParsers/StatReplacingParserTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Moq;
 using NUnit.Framework;
 using PoESkillTree.Engine.Computation.Common.Data;
 
@@ -8,7 +9,9 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
     [TestFixture]
     public class StatReplacingParserTest
     {
+#pragma warning disable 8618 // Initialized in SetUp
         private IReadOnlyList<StatReplacerData> _statReplacers;
+#pragma warning restore 8618
 
         [SetUp]
         public void SetUp()
@@ -26,7 +29,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
         [Test]
         public void IsIParserIReadOnlyList()
         {
-            var sut = new StatReplacingParser<string>(null, _statReplacers);
+            var sut = new StatReplacingParser<string>(null!, _statReplacers);
 
             Assert.IsInstanceOf<IStringParser<IReadOnlyList<string>>>(sut);
         }
@@ -35,7 +38,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
         [TestCase(false, ExpectedResult = false)]
         public bool TryParseWithoutReplacementPassesSuccessfullyParsed(bool innerSuccess)
         {
-            var inner = StringParserTestUtils.MockParser("stat", innerSuccess, default, "").Object;
+            var inner = StringParserTestUtils.MockParser("stat", innerSuccess, "", "").Object;
             var sut = new StatReplacingParser<string>(inner, _statReplacers);
 
             var (actual, _, _) = sut.Parse("stat");
@@ -59,7 +62,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
         public void TryParseWithoutReplacementPassesResult()
         {
             const string expected = "result";
-            var inner = StringParserTestUtils.MockParser("stat", default, default, expected).Object;
+            var inner = StringParserTestUtils.MockParser("stat", default, "", expected).Object;
             var sut = new StatReplacingParser<string>(inner, _statReplacers);
 
             var (_, _, actual) = sut.Parse("stat");
@@ -75,9 +78,9 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
         public bool TryParseWithManyReplacementsReturnsCorrectSuccessfullyParsed(params bool[] successes)
         {
             var inner = StringParserTestUtils.MockParser(
-                ("stat1", new StringParseResult<string>(successes[0], default, default)),
-                ("stat2", new StringParseResult<string>(successes[1], default, default)),
-                ("stat3", new StringParseResult<string>(successes[2], default, default))).Object;
+                ("stat1", new StringParseResult<string>(successes[0], "", default)),
+                ("stat2", new StringParseResult<string>(successes[1], "", default)),
+                ("stat3", new StringParseResult<string>(successes[2], "", default))).Object;
             var sut = new StatReplacingParser<string>(inner, _statReplacers);
 
             var (actual, _, _) = sut.Parse("plain stat");
@@ -105,9 +108,9 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
         {
             string[] results = { "r1", "r2", "r3" };
             var inner = StringParserTestUtils.MockParser(
-                ("stat1", new StringParseResult<string>(default, default, results[0])),
-                ("stat2", new StringParseResult<string>(default, default, results[1])),
-                ("stat3", new StringParseResult<string>(default, default, results[2]))).Object;
+                ("stat1", new StringParseResult<string>(default, "", results[0])),
+                ("stat2", new StringParseResult<string>(default, "", results[1])),
+                ("stat3", new StringParseResult<string>(default, "", results[2]))).Object;
             var sut = new StatReplacingParser<string>(inner, _statReplacers);
 
             var (_, _, actual) = sut.Parse("plain stat");
@@ -118,7 +121,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
         [Test]
         public void TryParseWithEmptyReplacementReturnsSuccess()
         {
-            var sut = new StatReplacingParser<string>(null, _statReplacers);
+            var sut = new StatReplacingParser<string>(Mock.Of<IStringParser<string>>(), _statReplacers);
 
             var (actual, _, _) = sut.Parse("removed");
 
@@ -128,7 +131,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
         [Test]
         public void TryParseWithEmptyReplacementReturnsEmptyStringAsRemaining()
         {
-            var sut = new StatReplacingParser<string>(null, _statReplacers);
+            var sut = new StatReplacingParser<string>(Mock.Of<IStringParser<string>>(), _statReplacers);
 
             var (_, actual, _) = sut.Parse("removed");
 
@@ -138,7 +141,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
         [Test]
         public void TryParseWithEmptyReplacementReturnsEmptyListAsResult()
         {
-            var sut = new StatReplacingParser<string>(null, _statReplacers);
+            var sut = new StatReplacingParser<string>(Mock.Of<IStringParser<string>>(), _statReplacers);
 
             var (_, _, actual) = sut.Parse("removed");
 
@@ -153,7 +156,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
         [TestCase("unknown stat", new[] { "unknown stat" })]
         public void TryParseCallsInnerCorrectly(string stat, string[] expectedParts)
         {
-            var setup = expectedParts.Select(s => (s, new StringParseResult<string>(default, default, default)));
+            var setup = expectedParts.Select(s => (s, new StringParseResult<string>(default, "", default)));
             var innerMock = StringParserTestUtils.MockParser(setup.ToArray());
 
             var sut = new StatReplacingParser<string>(innerMock.Object, _statReplacers);
@@ -184,7 +187,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
         [Test]
         public void TryParseMustFindFullMatchToReplaceStat()
         {
-            var innerMock = StringParserTestUtils.MockParser("plain stat something", default, default, "");
+            var innerMock = StringParserTestUtils.MockParser("plain stat something", default, "", "");
             var sut = new StatReplacingParser<string>(innerMock.Object, _statReplacers);
 
             sut.Parse("plain stat something");

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/StringParsers/StringParserTestUtils.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/StringParsers/StringParserTestUtils.cs
@@ -7,14 +7,17 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
     {
         public static Mock<IStringParser<TResult>> MockParser<TResult>(
             string modifier, bool successfullyParsed, string remainingSubstring, TResult result)
+            where TResult : class
             => MockParser(modifier, new StringParseResult<TResult>(successfullyParsed, remainingSubstring, result));
 
         private static Mock<IStringParser<TResult>> MockParser<TResult>(
             string modifier, StringParseResult<TResult> result)
+            where TResult : class
             => MockParser((modifier, result));
 
         public static Mock<IStringParser<TResult>> MockParser<TResult>(
             params (string modifier, StringParseResult<TResult> result)[] setup)
+            where TResult : class
         {
             var mock = new Mock<IStringParser<TResult>>();
             foreach (var (modifier, result) in setup)
@@ -27,9 +30,11 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
 
         public static void VerifyParse<TResult>(this Mock<IStringParser<TResult>> @this,
             string modifier, Func<Times> times)
+            where TResult : class
             => @this.Verify(p => p.Parse(modifier), times);
 
         public static void VerifyParse<TResult>(this Mock<IStringParser<TResult>> @this, string modifier)
+            where TResult : class
             => @this.Verify(p => p.Parse(modifier));
     }
 }

--- a/PoESkillTree.Engine.Computation.Parsing.Tests/StringParsers/ValidatingParserTest.cs
+++ b/PoESkillTree.Engine.Computation.Parsing.Tests/StringParsers/ValidatingParserTest.cs
@@ -9,7 +9,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
         [Test]
         public void IsIParser()
         {
-            var sut = new ValidatingParser<string>(null);
+            var sut = new ValidatingParser<string>(null!);
 
             Assert.IsInstanceOf<IStringParser<string>>(sut);
         }

--- a/PoESkillTree.Engine.Computation.Parsing/CoreParser.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/CoreParser.cs
@@ -59,7 +59,7 @@ namespace PoESkillTree.Engine.Computation.Parsing
                 var (success, remaining, result) = _parser.Value(parameter);
                 if (success)
                 {
-                    return ParseResult.Success(result);
+                    return ParseResult.Success(result!);
                 }
                 var parseResult = ParseResult.Failure(parameter.ModifierLine, remaining);
                 Log.Debug($"ParseResult.Failure{parseResult}");

--- a/PoESkillTree.Engine.Computation.Parsing/ItemParsers/ItemPropertyParser.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/ItemParsers/ItemPropertyParser.cs
@@ -15,7 +15,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.ItemParsers
     public class ItemPropertyParser : IParser<PartialItemParserParameter>
     {
         private readonly IBuilderFactories _builderFactories;
-        private ModifierCollection _modifiers;
+        private ModifierCollection? _modifiers;
 
         public ItemPropertyParser(IBuilderFactories builderFactories)
             => _builderFactories = builderFactories;
@@ -54,14 +54,14 @@ namespace PoESkillTree.Engine.Computation.Parsing.ItemParsers
             {
                 SetupDamageRelatedProperty(slot, _builderFactories.ActionBuilders.CriticalStrike.Chance);
                 // BaseSet CriticalStrike.Chance using BaseChance to allow overriding.
-                _modifiers.AddLocal(
+                _modifiers!.AddLocal(
                     _builderFactories.ActionBuilders.CriticalStrike.Chance.WithSkills.With(SlotToHand(slot)).AsItemProperty,
                     Form.BaseSet,
                     _builderFactories.ActionBuilders.CriticalStrike.BaseChance.WithSkills.With(SlotToHand(slot)).Value);
                 SetupDamageRelatedProperty(slot, _builderFactories.StatBuilders.CastRate);
                 // BaseSet CastRate property using BaseCastTime. This additional step is necessary because of modifiers
                 // attacks like Whirling Blades or Leap Slam that modify/override the BaseCastTime.
-                _modifiers.AddLocal(
+                _modifiers!.AddLocal(
                     _builderFactories.StatBuilders.CastRate.WithSkills.With(SlotToHand(slot)).AsItemProperty,
                     Form.BaseSet,
                     _builderFactories.StatBuilders.BaseCastTime.WithSkills.With(SlotToHand(slot)).Value.Invert);
@@ -83,7 +83,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.ItemParsers
             => SetupProperty(stat.WithSkills.With(SlotToHand(slot)));
 
         private void SetupProperty(IStatBuilder stat)
-            => _modifiers.AddLocal(stat, Form.BaseSet, stat.AsItemProperty.Value);
+            => _modifiers!.AddLocal(stat, Form.BaseSet, stat.AsItemProperty.Value);
 
         private void AddPropertyModifiers(ItemSlot slot, BaseItemDefinition baseItemDefinition)
         {
@@ -107,12 +107,12 @@ namespace PoESkillTree.Engine.Computation.Parsing.ItemParsers
                         SetProperty(_builderFactories.ActionBuilders.Block.AttackChance, value);
                         break;
                     case "critical_strike_chance":
-                        _modifiers.AddLocal(
+                        _modifiers!.AddLocal(
                             _builderFactories.ActionBuilders.CriticalStrike.BaseChance.WithSkills.With(SlotToHand(slot)),
                             Form.BaseSet, value / 100D);
                         break;
                     case "attack_time":
-                        _modifiers.AddLocal(
+                        _modifiers!.AddLocal(
                             _builderFactories.StatBuilders.BaseCastTime.WithSkills.With(SlotToHand(slot)),
                             Form.BaseSet, value / 1000D);
                         break;
@@ -141,7 +141,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.ItemParsers
                     _builderFactories.ValueBuilders.Create(physDamageMin),
                     _builderFactories.ValueBuilders.Create(physDamageMax.Value));
                 var stat = _builderFactories.DamageTypeBuilders.Physical.Damage.WithSkills.With(SlotToHand(slot));
-                _modifiers.AddLocal(stat.AsItemProperty, Form.BaseSet, value);
+                _modifiers!.AddLocal(stat.AsItemProperty, Form.BaseSet, value);
             }
         }
 
@@ -163,7 +163,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.ItemParsers
             }
 
             void Add(IStatBuilder stat)
-                => _modifiers.AddLocal(stat.AsItemProperty, Form.Increase, value);
+                => _modifiers!.AddLocal(stat.AsItemProperty, Form.Increase, value);
         }
 
         private void AddRequirementModifiers(Item item, BaseItemDefinition baseItemDefinition)
@@ -189,7 +189,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.ItemParsers
             => SetProperty(stat.WithSkills.With(SlotToHand(slot)), value);
 
         private void SetProperty(IStatBuilder stat, double value)
-            => _modifiers.AddLocal(stat.AsItemProperty, Form.BaseSet, value);
+            => _modifiers!.AddLocal(stat.AsItemProperty, Form.BaseSet, value);
 
         private static AttackDamageHand SlotToHand(ItemSlot slot)
             => slot == ItemSlot.MainHand ? AttackDamageHand.MainHand : AttackDamageHand.OffHand;

--- a/PoESkillTree.Engine.Computation.Parsing/ModifierCollection.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/ModifierCollection.cs
@@ -32,23 +32,23 @@ namespace PoESkillTree.Engine.Computation.Parsing
 
         public IReadOnlyList<Modifier> Modifiers => _modifiers;
 
-        public void AddLocal(IStatBuilder stat, Form form, double value, IConditionBuilder condition = null)
+        public void AddLocal(IStatBuilder stat, Form form, double value, IConditionBuilder? condition = null)
             => AddLocal(stat, form, _builderFactories.ValueBuilders.Create(value), condition);
 
-        public void AddLocal(IStatBuilder stat, Form form, IValueBuilder value, IConditionBuilder condition = null)
+        public void AddLocal(IStatBuilder stat, Form form, IValueBuilder value, IConditionBuilder? condition = null)
             => Add(stat, form, value, condition, _localModifierSource);
 
-        public void AddGlobal(IStatBuilder stat, Form form, double value, IConditionBuilder condition = null)
+        public void AddGlobal(IStatBuilder stat, Form form, double value, IConditionBuilder? condition = null)
             => AddGlobal(stat, form, _builderFactories.ValueBuilders.Create(value), condition);
 
-        public void AddGlobal(IStatBuilder stat, Form form, bool value, IConditionBuilder condition = null)
+        public void AddGlobal(IStatBuilder stat, Form form, bool value, IConditionBuilder? condition = null)
             => AddGlobal(stat, form, _builderFactories.ValueBuilders.Create(value), condition);
 
-        public void AddGlobal(IStatBuilder stat, Form form, IValueBuilder value, IConditionBuilder condition = null)
+        public void AddGlobal(IStatBuilder stat, Form form, IValueBuilder value, IConditionBuilder? condition = null)
             => Add(stat, form, value, condition, _globalModifierSource);
 
         private void Add(
-            IStatBuilder stat, Form form, IValueBuilder value, IConditionBuilder condition,
+            IStatBuilder stat, Form form, IValueBuilder value, IConditionBuilder? condition,
             ModifierSource modifierSource)
         {
             var builder = _modifierBuilder

--- a/PoESkillTree.Engine.Computation.Parsing/PoESkillTree.Engine.Computation.Parsing.csproj
+++ b/PoESkillTree.Engine.Computation.Parsing/PoESkillTree.Engine.Computation.Parsing.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Version>1.0.0</Version>
     <FileVersion>1.0.0.0</FileVersion>

--- a/PoESkillTree.Engine.Computation.Parsing/PoESkillTree.Engine.Computation.Parsing.csproj
+++ b/PoESkillTree.Engine.Computation.Parsing/PoESkillTree.Engine.Computation.Parsing.csproj
@@ -33,6 +33,10 @@
     <PackageReference Include="Enums.NET" Version="2.3.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All" />
     <PackageReference Include="morelinq" Version="3.2.0" />
+    <PackageReference Include="Nullable" Version="1.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PoESkillTree.Engine.Utils\PoESkillTree.Engine.Utils.csproj" />

--- a/PoESkillTree.Engine.Computation.Parsing/PoESkillTree.Engine.Computation.Parsing.csproj
+++ b/PoESkillTree.Engine.Computation.Parsing/PoESkillTree.Engine.Computation.Parsing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8</LangVersion>
     <Version>1.0.0</Version>
     <FileVersion>1.0.0.0</FileVersion>
 
@@ -17,6 +17,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSources>true</IncludeSources>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="LibLog" Version="5.0.6">

--- a/PoESkillTree.Engine.Computation.Parsing/PoESkillTree.Engine.Computation.Parsing.csproj
+++ b/PoESkillTree.Engine.Computation.Parsing/PoESkillTree.Engine.Computation.Parsing.csproj
@@ -20,6 +20,9 @@
 
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <WarningsAsErrors>8600;8601;8602;8603;8604;8613;8619;8620;8625</WarningsAsErrors>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="LibLog" Version="5.0.6">
       <PrivateAssets>all</PrivateAssets>
@@ -28,7 +31,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Enums.NET" Version="2.3.2" />
-    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All" />
     <PackageReference Include="morelinq" Version="3.2.0" />
   </ItemGroup>

--- a/PoESkillTree.Engine.Computation.Parsing/SkillParsers/ActiveSkillGeneralParser.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/SkillParsers/ActiveSkillGeneralParser.cs
@@ -21,7 +21,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
     {
         private readonly IBuilderFactories _builderFactories;
 
-        private SkillModifierCollection _parsedModifiers;
+        private SkillModifierCollection? _parsedModifiers;
 
         public ActiveSkillGeneralParser(IBuilderFactories builderFactories)
             => _builderFactories = builderFactories;
@@ -117,11 +117,12 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
 
             for (var partIndex = 0; partIndex < partCount; partIndex++)
             {
-                if (DetermineHitDamageSource(preParseResult, partIndex) is DamageSource damageSource)
+                var damageSource = DetermineHitDamageSource(preParseResult, partIndex);
+                if (damageSource != null)
                 {
                     var condition =
                         partCount > 1 ? _builderFactories.StatBuilders.MainSkillPart.Value.Eq(partIndex) : null;
-                    _parsedModifiers.AddGlobalForMainSkill(MetaStats.SkillHitDamageSource,
+                    _parsedModifiers!.AddGlobalForMainSkill(MetaStats.SkillHitDamageSource,
                         Form.TotalOverride, (int) damageSource, condition);
                 }
             }

--- a/PoESkillTree.Engine.Computation.Parsing/SkillParsers/ActiveSkillLevelParser.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/SkillParsers/ActiveSkillLevelParser.cs
@@ -15,8 +15,8 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
     {
         private readonly IBuilderFactories _builderFactories;
 
-        private SkillModifierCollection _modifiers;
-        private SkillPreParseResult _preParseResult;
+        private SkillModifierCollection? _modifiers;
+        private SkillPreParseResult? _preParseResult;
 
         public ActiveSkillLevelParser(IBuilderFactories builderFactories)
             => _builderFactories = builderFactories;
@@ -73,12 +73,12 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
         {
             var isReservation = MetaStats
                 .SkillHasType(skill.ItemSlot, skill.SocketIndex, ActiveSkillType.ManaCostIsReservation).IsSet;
-            var isReservationAndActive = isReservation.And(_preParseResult.IsActiveSkill);
+            var isReservationAndActive = isReservation.And(_preParseResult!.IsActiveSkill);
             var isPercentage = MetaStats
                 .SkillHasType(skill.ItemSlot, skill.SocketIndex, ActiveSkillType.ManaCostIsPercentage).IsSet;
             var skillBuilder = _builderFactories.SkillBuilders.FromId(_preParseResult.SkillDefinition.Id);
 
-            _modifiers.AddGlobal(skillBuilder.Reservation, Form.BaseSet, costStat.Value, isReservationAndActive);
+            _modifiers!.AddGlobal(skillBuilder.Reservation, Form.BaseSet, costStat.Value, isReservationAndActive);
 
             foreach (var pool in Enums.GetValues<Pool>())
             {

--- a/PoESkillTree.Engine.Computation.Parsing/SkillParsers/SkillKeywordParser.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/SkillParsers/SkillKeywordParser.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using EnumsNET;
-using MoreLinq;
 using PoESkillTree.Engine.Computation.Common;
 using PoESkillTree.Engine.Computation.Common.Builders;
 using PoESkillTree.Engine.Computation.Common.Builders.Conditions;
@@ -11,7 +10,11 @@ using PoESkillTree.Engine.Computation.Common.Builders.Stats;
 using PoESkillTree.Engine.GameModel;
 using PoESkillTree.Engine.GameModel.Items;
 using PoESkillTree.Engine.GameModel.Skills;
+using static MoreLinq.Extensions.IndexExtension;
+#if NETSTANDARD2_0
 using PoESkillTree.Engine.Utils.Extensions;
+using static MoreLinq.Extensions.ToHashSetExtension;
+#endif
 
 namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
 {

--- a/PoESkillTree.Engine.Computation.Parsing/SkillParsers/SkillKeywordParser.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/SkillParsers/SkillKeywordParser.cs
@@ -38,9 +38,9 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
         private readonly IBuilderFactories _builderFactories;
         private readonly ISkillKeywordSelector _keywordSelector;
 
-        private ModifierCollection _parsedModifiers;
-        private ISet<UntranslatedStat> _parsedStats;
-        private SkillPreParseResult _preParseResult;
+        private ModifierCollection? _parsedModifiers;
+        private ISet<UntranslatedStat>? _parsedStats;
+        private SkillPreParseResult? _preParseResult;
 
         private SkillKeywordParser(IBuilderFactories builderFactories, ISkillKeywordSelector keywordSelector)
             => (_builderFactories, _keywordSelector) =
@@ -91,18 +91,18 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
 
         private void AddKeywordModifiers(Func<Keyword, IStatBuilder> statFactory, IConditionBuilder condition)
         {
-            var keywords = _keywordSelector.GetKeywords(_preParseResult.SkillDefinition);
+            var keywords = _keywordSelector.GetKeywords(_preParseResult!.SkillDefinition);
             AddKeywordModifiers(keywords, statFactory, _ => condition);
         }
 
         private void AddPartKeywordModifiers(
             Func<Keyword, IStatBuilder> statFactory,
             Func<Keyword, int, IConditionBuilder> conditionFactory,
-            Func<Keyword, int, bool> preCondition = null)
+            Func<Keyword, int, bool>? preCondition = null)
         {
             if (preCondition is null)
                 preCondition = (_, __) => true;
-            var keywordsPerPart = _keywordSelector.GetKeywordsPerPart(_preParseResult.SkillDefinition);
+            var keywordsPerPart = _keywordSelector.GetKeywordsPerPart(_preParseResult!.SkillDefinition);
             if (keywordsPerPart.Count == 1)
             {
                 AddKeywordModifiers(keywordsPerPart[0], statFactory,
@@ -119,19 +119,19 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
 
         private void AddKeywordModifiers(
             IEnumerable<Keyword> keywords, Func<Keyword, IStatBuilder> statFactory,
-            Func<Keyword, IConditionBuilder> conditionFactory, Func<Keyword, bool> preCondition = null)
+            Func<Keyword, IConditionBuilder> conditionFactory, Func<Keyword, bool>? preCondition = null)
         {
             if (preCondition != null)
                 keywords = keywords.Where(preCondition);
             foreach (var keyword in keywords)
             {
-                _parsedModifiers.AddGlobal(statFactory(keyword), Form.TotalOverride, 1, conditionFactory(keyword));
+                _parsedModifiers!.AddGlobal(statFactory(keyword), Form.TotalOverride, 1, conditionFactory(keyword));
             }
         }
 
         private ISet<int> GetPartsWithFlagStat(string statId)
         {
-            var level = _preParseResult.LevelDefinition;
+            var level = _preParseResult!.LevelDefinition;
             if (MatchFlagStat(level.Stats, statId))
                 return Enumerable.Range(0, level.AdditionalStatsPerPart.Count).ToHashSet();
 
@@ -147,9 +147,9 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
         private bool MatchFlagStat(IEnumerable<UntranslatedStat> stats, string statId)
         {
             var firstMatch = stats.FirstOrDefault(s => s.StatId == statId);
-            if (firstMatch is UntranslatedStat stat)
+            if (firstMatch != null)
             {
-                _parsedStats.Add(stat);
+                _parsedStats!.Add(firstMatch);
                 return true;
             }
             return false;

--- a/PoESkillTree.Engine.Computation.Parsing/SkillParsers/SkillModifierCollection.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/SkillParsers/SkillModifierCollection.cs
@@ -18,19 +18,19 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
             => _isMainSkill = isMainSkill;
 
         public void AddLocalForMainSkill(
-            IStatBuilder stat, Form form, double value, IConditionBuilder condition = null)
+            IStatBuilder stat, Form form, double value, IConditionBuilder? condition = null)
             => AddLocal(stat, form, value, CombineWithNullableCondition(_isMainSkill, condition));
 
         public void AddGlobalForMainSkill(
-            IStatBuilder stat, Form form, double value, IConditionBuilder condition = null)
+            IStatBuilder stat, Form form, double value, IConditionBuilder? condition = null)
             => AddGlobal(stat, form, value, CombineWithNullableCondition(_isMainSkill, condition));
 
         public void AddGlobalForMainSkill(
-            IStatBuilder stat, Form form, IValueBuilder value, IConditionBuilder condition = null)
+            IStatBuilder stat, Form form, IValueBuilder value, IConditionBuilder? condition = null)
             => AddGlobal(stat, form, value, CombineWithNullableCondition(_isMainSkill, condition));
 
         private static IConditionBuilder CombineWithNullableCondition(
-            IConditionBuilder left, IConditionBuilder right = null)
+            IConditionBuilder left, IConditionBuilder? right = null)
             => right is null ? left : left.And(right);
     }
 }

--- a/PoESkillTree.Engine.Computation.Parsing/SkillParsers/SupportSkillGeneralParser.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/SkillParsers/SupportSkillGeneralParser.cs
@@ -15,8 +15,8 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
     {
         private readonly IBuilderFactories _builderFactories;
 
-        private ModifierCollection _parsedModifiers;
-        private SkillPreParseResult _preParseResult;
+        private ModifierCollection? _parsedModifiers;
+        private SkillPreParseResult? _preParseResult;
 
         public SupportSkillGeneralParser(IBuilderFactories builderFactories)
             => _builderFactories = builderFactories;
@@ -42,12 +42,12 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
 
         private void AddInstanceModifiers()
         {
-            var addedKeywords = _preParseResult.SkillDefinition.SupportSkill.AddedKeywords
+            var addedKeywords = _preParseResult!.SkillDefinition.SupportSkill.AddedKeywords
                 .Where(k => !_preParseResult.MainSkillDefinition.ActiveSkill.Keywords.Contains(k));
             foreach (var keyword in addedKeywords)
             {
                 var keywordBuilder = _builderFactories.KeywordBuilders.From(keyword);
-                _parsedModifiers.AddGlobal(_builderFactories.SkillBuilders[keywordBuilder].CombinedInstances,
+                _parsedModifiers!.AddGlobal(_builderFactories.SkillBuilders[keywordBuilder].CombinedInstances,
                     Form.BaseAdd, 1, _preParseResult.IsActiveSkill);
             }
         }

--- a/PoESkillTree.Engine.Computation.Parsing/SkillParsers/TranslatingSkillParser.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/SkillParsers/TranslatingSkillParser.cs
@@ -33,8 +33,8 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
         private readonly IBuilderFactories _builderFactories;
         private readonly UntranslatedStatParserFactory _statParserFactory;
 
-        private SkillPreParseResult _preParseResult;
-        private IEnumerable<UntranslatedStat> _parsedStats;
+        private SkillPreParseResult? _preParseResult;
+        private IEnumerable<UntranslatedStat>? _parsedStats;
 
         public TranslatingSkillParser(
             IBuilderFactories builderFactories, UntranslatedStatParserFactory statParserFactory)
@@ -83,12 +83,12 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
         }
 
         private ParseResult TranslateAndParse(IEnumerable<UntranslatedStat> stats, IConditionBuilder condition)
-            => TranslateAndParse(_preParseResult.SkillDefinition.StatTranslationFile, stats, condition);
+            => TranslateAndParse(_preParseResult!.SkillDefinition.StatTranslationFile, stats, condition);
 
         private ParseResult TranslateAndParse(
             string statTranslationFileName, IEnumerable<UntranslatedStat> stats, IConditionBuilder condition)
         {
-            var result = TranslateAndParse(_preParseResult.LocalSource, stats, Entity.Character,
+            var result = TranslateAndParse(_preParseResult!.LocalSource, stats, Entity.Character,
                 statTranslationFileName);
             return result.ApplyCondition(condition.Build);
         }
@@ -96,7 +96,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
         private ParseResult TranslateAndParseBuff(IEnumerable<BuffStat> buffStats, IConditionBuilder condition)
         {
             var results = new List<ParseResult>();
-            var buffBuilder = _builderFactories.SkillBuilders.FromId(_preParseResult.SkillDefinition.Id).Buff;
+            var buffBuilder = _builderFactories.SkillBuilders.FromId(_preParseResult!.SkillDefinition.Id).Buff;
             var statLookup = buffStats
                 .SelectMany(t => t.AffectedEntities.Select(e => (e, t.Stat)))
                 .ToLookup();

--- a/PoESkillTree.Engine.Computation.Parsing/SkillParsers/TranslatingSkillParser.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/SkillParsers/TranslatingSkillParser.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using MoreLinq;
 using PoESkillTree.Engine.Computation.Common;
 using PoESkillTree.Engine.Computation.Common.Builders;
 using PoESkillTree.Engine.Computation.Common.Builders.Conditions;
@@ -10,6 +9,12 @@ using PoESkillTree.Engine.GameModel;
 using PoESkillTree.Engine.GameModel.Skills;
 using PoESkillTree.Engine.GameModel.StatTranslation;
 using PoESkillTree.Engine.Utils.Extensions;
+using static MoreLinq.Extensions.IndexExtension;
+using static MoreLinq.Extensions.PartitionExtension;
+using static MoreLinq.Extensions.ToLookupExtension;
+#if NETSTANDARD2_0
+using static MoreLinq.Extensions.ToHashSetExtension;
+#endif
 
 namespace PoESkillTree.Engine.Computation.Parsing.SkillParsers
 {

--- a/PoESkillTree.Engine.Computation.Parsing/StringParsers/CachingStringParser.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/StringParsers/CachingStringParser.cs
@@ -5,6 +5,7 @@
     /// </summary>
     public class CachingStringParser<T>
         : GenericCachingParser<string, StringParseResult<T>>, IStringParser<T>
+        where T : class
     {
         public CachingStringParser(IStringParser<T> decoratedParser)
             : base(decoratedParser.Parse)

--- a/PoESkillTree.Engine.Computation.Parsing/StringParsers/CompositeParser.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/StringParsers/CompositeParser.cs
@@ -40,7 +40,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
                 remaining = innerRemaining;
                 if (innerSuccess)
                 {
-                    results.Add(innerResult);
+                    results.Add(innerResult!);
                     step = _stepper.NextOnSuccess(step);
                 }
                 else

--- a/PoESkillTree.Engine.Computation.Parsing/StringParsers/CompositeParser.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/StringParsers/CompositeParser.cs
@@ -18,6 +18,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
     /// </para>
     /// </summary>
     public class CompositeParser<TInnerResult, TStep> : IStringParser<IReadOnlyList<TInnerResult>>
+        where TInnerResult : class
     {
         private readonly IStepper<TStep> _stepper;
         private readonly Func<TStep, IStringParser<TInnerResult>> _stepToParserFunc;

--- a/PoESkillTree.Engine.Computation.Parsing/StringParsers/IStringParser.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/StringParsers/IStringParser.cs
@@ -5,6 +5,7 @@
     /// </summary>
     /// <typeparam name="TResult">The type of parsing results.</typeparam>
     public interface IStringParser<TResult>
+        where TResult : class
     {
         StringParseResult<TResult> Parse(string modifierLine);
     }

--- a/PoESkillTree.Engine.Computation.Parsing/StringParsers/MatcherDataParser.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/StringParsers/MatcherDataParser.cs
@@ -43,9 +43,9 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
 
         public StringParseResult<MatcherDataParseResult> Parse(string modifierLine)
         {
-            Match longestMatch = null;
-            MatcherData matchingData = null;
-            Regex matchingRegex = null;
+            Match? longestMatch = null;
+            MatcherData? matchingData = null;
+            Regex? matchingRegex = null;
             foreach (var (data, regex) in _dataWithRegexes)
             {
                 var match = regex.Match(modifierLine);
@@ -62,7 +62,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
 
             return (true,
                 GetRemaining(matchingData, modifierLine, longestMatch),
-                new MatcherDataParseResult(matchingData.Modifier, SelectGroups(matchingRegex, longestMatch.Groups)));
+                new MatcherDataParseResult(matchingData.Modifier, SelectGroups(matchingRegex!, longestMatch.Groups)));
         }
 
         private static string GetRemaining(MatcherData matcherData, string stat, Match match)

--- a/PoESkillTree.Engine.Computation.Parsing/StringParsers/ResolvingParser.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/StringParsers/ResolvingParser.cs
@@ -41,11 +41,11 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
         public StringParseResult<IIntermediateModifier> Parse(string modifierLine)
         {
             var (successfullyParsed, remaining, innerResult) = _innerParser.Parse(modifierLine);
-            IIntermediateModifier result;
+            IIntermediateModifier? result;
 
             if (successfullyParsed)
             {
-                var groups = innerResult.RegexGroups;
+                var groups = innerResult!.RegexGroups;
                 var context = CreateContext(groups, "");
                 result = _modifierResolver.Resolve(innerResult.Modifier, context);
             }

--- a/PoESkillTree.Engine.Computation.Parsing/StringParsers/StatNormalizingParser.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/StringParsers/StatNormalizingParser.cs
@@ -7,6 +7,7 @@
     /// </para>
     /// </summary>
     public class StatNormalizingParser<TResult> : IStringParser<TResult>
+        where TResult : class
     {
         private readonly IStringParser<TResult> _inner;
 

--- a/PoESkillTree.Engine.Computation.Parsing/StringParsers/StatReplacingParser.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/StringParsers/StatReplacingParser.cs
@@ -43,7 +43,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
             {
                 var (innerSuccess, innerRemaining, innerResult) = _inner.Parse(replacementStat);
                 successfullyParsed &= innerSuccess;
-                results.Add(innerResult);
+                results.Add(innerResult!);
                 if (!string.IsNullOrWhiteSpace(innerRemaining))
                 {
                     remainings.Add(innerRemaining);

--- a/PoESkillTree.Engine.Computation.Parsing/StringParsers/StatReplacingParser.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/StringParsers/StatReplacingParser.cs
@@ -16,6 +16,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
     /// </summary>
     /// <typeparam name="TResult">Type of the decorated parser's results</typeparam>
     public class StatReplacingParser<TResult> : IStringParser<IReadOnlyList<TResult>>
+        where TResult : class
     {
         private readonly IStringParser<TResult> _inner;
 

--- a/PoESkillTree.Engine.Computation.Parsing/StringParsers/StringParseResult.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/StringParsers/StringParseResult.cs
@@ -6,15 +6,16 @@
     /// type name.
     /// </summary>
     public class StringParseResult<T>
+        where T : class
     {
-        public StringParseResult(bool successfullyParsed, string remainingSubstring, T result)
+        public StringParseResult(bool successfullyParsed, string remainingSubstring, T? result)
             => (SuccessfullyParsed, RemainingSubstring, Result) = (successfullyParsed, remainingSubstring, result);
 
-        public void Deconstruct(out bool successfullyParsed, out string remainingSubstring, out T result)
+        public void Deconstruct(out bool successfullyParsed, out string remainingSubstring, out T? result)
             => (successfullyParsed, remainingSubstring, result) = (SuccessfullyParsed, RemainingSubstring, Result);
 
         public static implicit operator StringParseResult<T>(
-            (bool successfullyParsed, string remainingSubstring, T result) t)
+            (bool successfullyParsed, string remainingSubstring, T? result) t)
             => new StringParseResult<T>(t.successfullyParsed, t.remainingSubstring, t.result);
 
         /// <summary>
@@ -32,6 +33,6 @@
         /// The result of parsing. Not defined if <see cref="SuccessfullyParsed"/> is false. In that case it may be
         /// null or a partial result containing null properties and should only be used for debugging purposes.
         /// </summary>
-        public T Result { get; }
+        public T? Result { get; }
     }
 }

--- a/PoESkillTree.Engine.Computation.Parsing/StringParsers/ValidatingParser.cs
+++ b/PoESkillTree.Engine.Computation.Parsing/StringParsers/ValidatingParser.cs
@@ -12,6 +12,7 @@ namespace PoESkillTree.Engine.Computation.Parsing.StringParsers
     /// false even if the decorated parser's was true.
     /// </summary>
     public class ValidatingParser<TResult> : IStringParser<TResult>
+        where TResult : class
     {
         private readonly IStringParser<TResult> _inner;
 

--- a/PoESkillTree.Engine.GameModel.Tests/PoESkillTree.Engine.GameModel.Tests.csproj
+++ b/PoESkillTree.Engine.GameModel.Tests/PoESkillTree.Engine.GameModel.Tests.csproj
@@ -2,11 +2,13 @@
   <PropertyGroup>
     <RootNamespace>PoESkillTree.Engine.GameModel</RootNamespace>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8</LangVersion>
     <AssemblyTitle>PoESkillTree.Engine.GameModel.Tests</AssemblyTitle>
     <Product>PoESkillTree.Engine.GameModel.Tests</Product>
     <Copyright>Copyright ©  2018</Copyright>
     <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>8600;8601;8602;8603;8604;8619;8620</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/PoESkillTree.Engine.GameModel.Tests/PoESkillTree.Engine.GameModel.Tests.csproj
+++ b/PoESkillTree.Engine.GameModel.Tests/PoESkillTree.Engine.GameModel.Tests.csproj
@@ -10,15 +10,15 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.7.0" />
-    <PackageReference Include="Moq" Version="4.12.0" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="Moq" Version="4.13.0" />
     <PackageReference Include="morelinq" Version="3.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Data\base_items.json">

--- a/PoESkillTree.Engine.GameModel.Tests/PoESkillTree.Engine.GameModel.Tests.csproj
+++ b/PoESkillTree.Engine.GameModel.Tests/PoESkillTree.Engine.GameModel.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>PoESkillTree.Engine.GameModel</RootNamespace>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyTitle>PoESkillTree.Engine.GameModel.Tests</AssemblyTitle>
     <Product>PoESkillTree.Engine.GameModel.Tests</Product>

--- a/PoESkillTree.Engine.GameModel.Tests/Skills/SkillJsonDeserializerTest.cs
+++ b/PoESkillTree.Engine.GameModel.Tests/Skills/SkillJsonDeserializerTest.cs
@@ -25,7 +25,7 @@ namespace PoESkillTree.Engine.GameModel.Skills
 
             var baseItem = definition.BaseItem;
             Assert.IsNotNull(baseItem);
-            Assert.AreEqual("Frenzy", baseItem.DisplayName);
+            Assert.AreEqual("Frenzy", baseItem!.DisplayName);
             Assert.AreEqual("Metadata/Items/Gems/SkillGemFrenzy", baseItem.MetadataId);
             Assert.AreEqual(ReleaseState.Released, baseItem.ReleaseState);
             Assert.AreEqual(new[] { "dexterity", "active_skill", "attack", "melee", "bow" }, baseItem.GemTags);
@@ -204,7 +204,7 @@ namespace PoESkillTree.Engine.GameModel.Skills
 
             var releaseStates = definitions.Skills
                 .Where(d => d.BaseItem != null)
-                .Select(d => d.BaseItem.ReleaseState);
+                .Select(d => d.BaseItem!.ReleaseState);
             CollectionAssert.DoesNotContain(releaseStates, ReleaseState.Unreleased);
         }
 

--- a/PoESkillTree.Engine.GameModel.Tests/Skills/SupportabilityTesterTest.cs
+++ b/PoESkillTree.Engine.GameModel.Tests/Skills/SupportabilityTesterTest.cs
@@ -140,9 +140,7 @@ namespace PoESkillTree.Engine.GameModel.Skills
         {
             var skills = new[]
             {
-                SkillDefinition.CreateActive("activeBoolean", 100, "", null, null,
-                    new ActiveSkillDefinition("activeBoolean", 0, types, new string[0], null, null, false, null,
-                        null), null),
+                CreateActiveDefinition(types),
                 CreateSupportDefinition("SupportAuraDuration", 22, false,
                     new[]
                     {
@@ -176,9 +174,7 @@ namespace PoESkillTree.Engine.GameModel.Skills
         {
             var skills = new[]
             {
-                SkillDefinition.CreateActive("activeBoolean", 100, "", null, null,
-                    new ActiveSkillDefinition("activeBoolean", 0, types, new string[0], null, null, false, null,
-                        null), null),
+                CreateActiveDefinition(types),
                 CreateSupportDefinition("SupportAuraDuration", 22, false,
                     new[] { "aura", },
                     new[]
@@ -207,9 +203,10 @@ namespace PoESkillTree.Engine.GameModel.Skills
 
         private static IReadOnlyList<SkillDefinition> Skills => new[]
         {
-            SkillDefinition.CreateActive("active", 0, "", null, null,
-                new ActiveSkillDefinition("active", 0, new[] { "0", "1", "2" }, new[] { "3" }, null, null, false, null,
-                    null), null),
+            SkillDefinition.CreateActive("active", 0, "", new string[0], null,
+                new ActiveSkillDefinition("active", 0, new[] { "0", "1", "2" }, new[] { "3" }, new Keyword[0],
+                    new IReadOnlyList<Keyword>[0], false, null, new ItemClass[0]),
+                new Dictionary<int, SkillLevelDefinition>()),
             CreateSupportDefinition("1empty", 1, false, new string[0], new string[0], new string[0]),
             CreateSupportDefinition("2allows0", 2, false, new[] { "0" }, new string[0], new string[0]),
             CreateSupportDefinition("3allows0excludes1", 3, false, new[] { "0" }, new[] { "1" }, new string[0]),
@@ -232,11 +229,17 @@ namespace PoESkillTree.Engine.GameModel.Skills
             CreateSupportDefinition("21allows0gemsOnly", 21, true, new[] { "0" }, new string[0], new string[0]),
         };
 
+        private static SkillDefinition CreateActiveDefinition(string[] types)
+            => SkillDefinition.CreateActive("activeBoolean", 100, "", new string[0], null,
+                new ActiveSkillDefinition("activeBoolean", 0, types, new string[0], new Keyword[0],
+                    new IReadOnlyList<Keyword>[0], false, null, new ItemClass[0]),
+                new Dictionary<int, SkillLevelDefinition>());
+
         private static SkillDefinition CreateSupportDefinition(
             string id, int numericId, bool supportsGemsOnly, IEnumerable<string> allowedActiveSkillTypes,
             IEnumerable<string> excludedActiveSkillTypes, IEnumerable<string> addedActiveSkillTypes)
-            => SkillDefinition.CreateSupport(id, numericId, "", null, null,
+            => SkillDefinition.CreateSupport(id, numericId, "", new string[0], null,
                 new SupportSkillDefinition(supportsGemsOnly, allowedActiveSkillTypes, excludedActiveSkillTypes,
-                    addedActiveSkillTypes, null), null);
+                    addedActiveSkillTypes, new Keyword[0]), new Dictionary<int, SkillLevelDefinition>());
     }
 }

--- a/PoESkillTree.Engine.GameModel.Tests/StatTranslation/StatTranslatorTest.cs
+++ b/PoESkillTree.Engine.GameModel.Tests/StatTranslation/StatTranslatorTest.cs
@@ -8,7 +8,9 @@ namespace PoESkillTree.Engine.GameModel.StatTranslation
     [TestFixture]
     public class StatTranslatorTest
     {
+#pragma warning disable 8618 // Initialized in CreateTranslatorAsync
         private static StatTranslator _translator;
+#pragma warning restore
 
         [OneTimeSetUp]
         public static async Task CreateTranslatorAsync()
@@ -28,7 +30,7 @@ namespace PoESkillTree.Engine.GameModel.StatTranslation
                 { "base_cold_damage_resistance_%", 0 },
                 { "base_lightning_damage_resistance_%", -1 },
             };
-            string[] expected =
+            string?[] expected =
             {
                 "+30 to maximum Life",
                 null,
@@ -53,7 +55,7 @@ namespace PoESkillTree.Engine.GameModel.StatTranslation
                 { "weapon_physical_damage_%_to_add_as_each_element", 110 },
                 { "weapon_physical_damage_%_to_add_as_random_element", 0 }, // -110 + 110
             };
-            string[] expected =
+            string?[] expected =
             {
                 "Adds 10 to 20 Physical Damage",
                 "13% increased Attack Speed",
@@ -96,7 +98,7 @@ namespace PoESkillTree.Engine.GameModel.StatTranslation
             {
                 { "dummy_stat_display_nothing", 1 },
             };
-            string[] expected =
+            string?[] expected =
             {
                 null,
             };

--- a/PoESkillTree.Engine.GameModel/CharacterBaseStats.cs
+++ b/PoESkillTree.Engine.GameModel/CharacterBaseStats.cs
@@ -41,6 +41,8 @@ namespace PoESkillTree.Engine.GameModel
         public int UnarmedRange(CharacterClass c) => _charactertDict[c].Unarmed.Range;
     }
 
+#pragma warning disable 8618 // Initialization is done through deserialization
+
     public class JsonCharacter
     {
         [JsonProperty("name")]
@@ -85,4 +87,6 @@ namespace PoESkillTree.Engine.GameModel
         [JsonProperty("range")]
         public int Range { get; set; }
     }
+
+#pragma warning restore
 }

--- a/PoESkillTree.Engine.GameModel/Items/XmlUniqueList.cs
+++ b/PoESkillTree.Engine.GameModel/Items/XmlUniqueList.cs
@@ -4,6 +4,8 @@ namespace PoESkillTree.Engine.GameModel.Items
 {
     // Contains the classes that allow serialization and deserialization of Uniques.xml
 
+#pragma warning disable 8618 // Initialization is done through deserialization
+
     [XmlRoot(Namespace = "", IsNullable = false, ElementName = "UniqueList")]
     public class XmlUniqueList
     {
@@ -32,4 +34,6 @@ namespace PoESkillTree.Engine.GameModel.Items
         public string[] Properties { get; set; }
 
     }
+
+#pragma warning restore
 }

--- a/PoESkillTree.Engine.GameModel/PoESkillTree.Engine.GameModel.csproj
+++ b/PoESkillTree.Engine.GameModel/PoESkillTree.Engine.GameModel.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Version>1.0.0</Version>
     <FileVersion>1.0.0.0</FileVersion>

--- a/PoESkillTree.Engine.GameModel/PoESkillTree.Engine.GameModel.csproj
+++ b/PoESkillTree.Engine.GameModel/PoESkillTree.Engine.GameModel.csproj
@@ -36,6 +36,10 @@
     <PackageReference Include="morelinq" Version="3.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.0.0" />
+    <PackageReference Include="Nullable" Version="1.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Data\RePoE\**" />

--- a/PoESkillTree.Engine.GameModel/PoESkillTree.Engine.GameModel.csproj
+++ b/PoESkillTree.Engine.GameModel/PoESkillTree.Engine.GameModel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8</LangVersion>
     <Version>1.0.0</Version>
     <FileVersion>1.0.0.0</FileVersion>
 
@@ -17,6 +17,11 @@
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSources>true</IncludeSources>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <WarningsAsErrors>8600;8601;8602;8603;8604;8613;8619;8620;8625</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="LibLog" Version="5.0.6">

--- a/PoESkillTree.Engine.GameModel/Skills/SkillDefinition.cs
+++ b/PoESkillTree.Engine.GameModel/Skills/SkillDefinition.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using PoESkillTree.Engine.GameModel.Items;
 using PoESkillTree.Engine.Utils;
 
@@ -10,21 +9,21 @@ namespace PoESkillTree.Engine.GameModel.Skills
     {
         private SkillDefinition(
             string id, int numericId, bool isSupport, string statTranslationFile, IReadOnlyList<string> partNames,
-            SkillBaseItemDefinition baseItem, ActiveSkillDefinition activeSkill, SupportSkillDefinition supportSkill,
+            SkillBaseItemDefinition? baseItem, ActiveSkillDefinition? activeSkill, SupportSkillDefinition? supportSkill,
             IReadOnlyDictionary<int, SkillLevelDefinition> levels)
             => (Id, NumericId, IsSupport, PartNames, BaseItem, ActiveSkill, SupportSkill, Levels, StatTranslationFile) =
-                (id, numericId, isSupport, partNames, baseItem, activeSkill, supportSkill, levels, statTranslationFile);
+                (id, numericId, isSupport, partNames, baseItem, activeSkill!, supportSkill!, levels, statTranslationFile);
 
         public static SkillDefinition CreateActive(
             string id, int numericId, string statTranslationFile, IReadOnlyList<string> partNames,
-            SkillBaseItemDefinition baseItem, ActiveSkillDefinition activeSkill,
+            SkillBaseItemDefinition? baseItem, ActiveSkillDefinition activeSkill,
             IReadOnlyDictionary<int, SkillLevelDefinition> levels)
             => new SkillDefinition(id, numericId, false, statTranslationFile, partNames, baseItem, activeSkill, null,
                 levels);
 
         public static SkillDefinition CreateSupport(
             string id, int numericId, string statTranslationFile, IReadOnlyList<string> partNames,
-            SkillBaseItemDefinition baseItem, SupportSkillDefinition supportSkill,
+            SkillBaseItemDefinition? baseItem, SupportSkillDefinition supportSkill,
             IReadOnlyDictionary<int, SkillLevelDefinition> levels)
             => new SkillDefinition(id, numericId, true, statTranslationFile, partNames, baseItem, null, supportSkill,
                 levels);
@@ -36,8 +35,7 @@ namespace PoESkillTree.Engine.GameModel.Skills
 
         public IReadOnlyList<string> PartNames { get; }
 
-        [CanBeNull]
-        public SkillBaseItemDefinition BaseItem { get; }
+        public SkillBaseItemDefinition? BaseItem { get; }
 
         public ActiveSkillDefinition ActiveSkill { get; }
         public SupportSkillDefinition SupportSkill { get; }

--- a/PoESkillTree.Engine.GameModel/Skills/SkillDefinitionExtension.cs
+++ b/PoESkillTree.Engine.GameModel/Skills/SkillDefinitionExtension.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using MoreLinq;
 using PoESkillTree.Engine.Utils;
+#if NETSTANDARD2_0
+using static MoreLinq.Extensions.ToHashSetExtension;
+#endif
 
 namespace PoESkillTree.Engine.GameModel.Skills
 {

--- a/PoESkillTree.Engine.GameModel/Skills/SkillDefinitionExtension.cs
+++ b/PoESkillTree.Engine.GameModel/Skills/SkillDefinitionExtension.cs
@@ -77,31 +77,31 @@ namespace PoESkillTree.Engine.GameModel.Skills
 
         public SkillPartDefinitionExtension(
             Func<IEnumerable<UntranslatedStat>, IEnumerable<UntranslatedStat>> statReplacer,
-            IEnumerable<Keyword> removedKeywords = null, IEnumerable<Keyword> addedKeywords = null)
+            IEnumerable<Keyword>? removedKeywords = null, IEnumerable<Keyword>? addedKeywords = null)
             : this(null, null, statReplacer, removedKeywords, addedKeywords)
         {
         }
 
         public SkillPartDefinitionExtension(
             IEnumerable<string> removedStats,
-            Func<IEnumerable<UntranslatedStat>, IEnumerable<UntranslatedStat>> statReplacer = null,
-            IEnumerable<Keyword> removedKeywords = null, IEnumerable<Keyword> addedKeywords = null)
+            Func<IEnumerable<UntranslatedStat>, IEnumerable<UntranslatedStat>>? statReplacer = null,
+            IEnumerable<Keyword>? removedKeywords = null, IEnumerable<Keyword>? addedKeywords = null)
             : this(removedStats, null, statReplacer, removedKeywords, addedKeywords)
         {
         }
 
         public SkillPartDefinitionExtension(
             IEnumerable<UntranslatedStat> addedStats,
-            Func<IEnumerable<UntranslatedStat>, IEnumerable<UntranslatedStat>> statReplacer = null,
-            IEnumerable<Keyword> removedKeywords = null, IEnumerable<Keyword> addedKeywords = null)
+            Func<IEnumerable<UntranslatedStat>, IEnumerable<UntranslatedStat>>? statReplacer = null,
+            IEnumerable<Keyword>? removedKeywords = null, IEnumerable<Keyword>? addedKeywords = null)
             : this(null, addedStats, statReplacer, removedKeywords, addedKeywords)
         {
         }
 
         public SkillPartDefinitionExtension(
-            IEnumerable<string> removedStats, IEnumerable<UntranslatedStat> addedStats,
-            Func<IEnumerable<UntranslatedStat>, IEnumerable<UntranslatedStat>> statReplacer = null,
-            IEnumerable<Keyword> removedKeywords = null, IEnumerable<Keyword> addedKeywords = null)
+            IEnumerable<string>? removedStats, IEnumerable<UntranslatedStat>? addedStats,
+            Func<IEnumerable<UntranslatedStat>, IEnumerable<UntranslatedStat>>? statReplacer = null,
+            IEnumerable<Keyword>? removedKeywords = null, IEnumerable<Keyword>? addedKeywords = null)
         {
             _removedStats = removedStats ?? new string[0];
             _addedStats = addedStats ?? new UntranslatedStat[0];

--- a/PoESkillTree.Engine.GameModel/Skills/SkillJsonDeserializer.cs
+++ b/PoESkillTree.Engine.GameModel/Skills/SkillJsonDeserializer.cs
@@ -274,12 +274,9 @@ namespace PoESkillTree.Engine.GameModel.Skills
             return stats;
         }
 
-        private static bool TryGetValues<T>(string propertyName, JToken firstToken, JToken secondToken,
-#if NETSTANDARD2_0
-            out T[] values)
-#else
+        private static bool TryGetValues<T>(
+            string propertyName, JToken firstToken, JToken secondToken,
             [NotNullWhen(true)] out T[]? values)
-#endif
         {
             var firstArray = GetValue<JArray>(propertyName, firstToken, secondToken);
             if (firstArray is null)
@@ -301,9 +298,7 @@ namespace PoESkillTree.Engine.GameModel.Skills
             return true;
         }
 
-#if !NETSTANDARD2_0
         [return: MaybeNull]
-#endif
         private static T GetValue<T>(string propertyName, JToken firstToken, JToken secondToken)
         {
             if (firstToken is JObject firstObject && firstObject.TryGetValue(propertyName, out var outToken))

--- a/PoESkillTree.Engine.GameModel/Skills/SkillJsonDeserializer.cs
+++ b/PoESkillTree.Engine.GameModel/Skills/SkillJsonDeserializer.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using EnumsNET;
-using MoreLinq;
 using Newtonsoft.Json.Linq;
 using PoESkillTree.Engine.GameModel.Items;
+#if NETSTANDARD2_0
+using static MoreLinq.Extensions.ToHashSetExtension;
+#endif
 
 namespace PoESkillTree.Engine.GameModel.Skills
 {

--- a/PoESkillTree.Engine.GameModel/Skills/SupportabilityTester.cs
+++ b/PoESkillTree.Engine.GameModel/Skills/SupportabilityTester.cs
@@ -1,7 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using MoreLinq;
-using PoESkillTree.Engine.Utils.Extensions;
+#if NETSTANDARD2_0
+using static MoreLinq.Extensions.ToHashSetExtension;
+#endif
 
 namespace PoESkillTree.Engine.GameModel.Skills
 {

--- a/PoESkillTree.Engine.GameModel/StatTranslation/JsonStatTranslation.cs
+++ b/PoESkillTree.Engine.GameModel/StatTranslation/JsonStatTranslation.cs
@@ -4,6 +4,8 @@ namespace PoESkillTree.Engine.GameModel.StatTranslation
 {
     // The classes used to deserialize RePoE's stat_translations
 
+#pragma warning disable 8618 // Initialization is done through deserialization
+
     public class JsonStatTranslation
     {
         [JsonProperty("English")]
@@ -39,4 +41,6 @@ namespace PoESkillTree.Engine.GameModel.StatTranslation
         [JsonProperty("max")]
         public int Max { get; set; } = int.MaxValue;
     }
+
+#pragma warning restore
 }

--- a/PoESkillTree.Engine.GameModel/StatTranslation/StatTranslator.cs
+++ b/PoESkillTree.Engine.GameModel/StatTranslation/StatTranslator.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using PoESkillTree.Engine.GameModel.Logging;
+using PoESkillTree.Engine.Utils.Extensions;
 using static MoreLinq.Extensions.MaxByExtension;
 using static MoreLinq.Extensions.ToDelimitedStringExtension;
 #if NETSTANDARD2_0
@@ -49,7 +49,7 @@ namespace PoESkillTree.Engine.GameModel.StatTranslation
             var unknownStats = unknownStatIds.Select(k => idStatDict[k]);
 
             var idValueDict = idStatDict.ToDictionary(p => p.Key, p => p.Value.Value);
-            var translatedStats = translations.Select(t => t.Translate(idValueDict)).Where(s => s != null);
+            var translatedStats = translations.Select(t => t.Translate(idValueDict)).WhereNotNull();
 
             return new StatTranslatorResult(translatedStats.ToList(), unknownStats.ToList());
 
@@ -60,8 +60,7 @@ namespace PoESkillTree.Engine.GameModel.StatTranslation
         /// <summary>
         /// Returns the translated strings for the given stat ids and values.
         /// </summary>
-        [ItemCanBeNull]
-        public IEnumerable<string> GetTranslations(IReadOnlyDictionary<string, int> idValueDict)
+        public IEnumerable<string?> GetTranslations(IReadOnlyDictionary<string, int> idValueDict)
             => GetTranslations(idValueDict.Keys).Select(t => t.Translate(idValueDict));
 
         /// <summary>

--- a/PoESkillTree.Engine.GameModel/StatTranslation/StatTranslator.cs
+++ b/PoESkillTree.Engine.GameModel/StatTranslation/StatTranslator.cs
@@ -2,8 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
-using MoreLinq;
 using PoESkillTree.Engine.GameModel.Logging;
+using static MoreLinq.Extensions.MaxByExtension;
+using static MoreLinq.Extensions.ToDelimitedStringExtension;
+#if NETSTANDARD2_0
+using static MoreLinq.Extensions.ToHashSetExtension;
+#endif
 
 namespace PoESkillTree.Engine.GameModel.StatTranslation
 {

--- a/PoESkillTree.Engine.GameModel/StatTranslation/Translation.cs
+++ b/PoESkillTree.Engine.GameModel/StatTranslation/Translation.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using JetBrains.Annotations;
 using MoreLinq;
 using PoESkillTree.Engine.GameModel.Items;
 using PoESkillTree.Engine.Utils.Extensions;
@@ -21,8 +20,7 @@ namespace PoESkillTree.Engine.GameModel.StatTranslation
         /// <returns>the translated values. Null if the values should not be translated, e.g. the stat should be 
         /// hidden. This is the case for stats without effect or stats that are not meant to be visible to players.
         /// </returns>
-        [CanBeNull]
-        string Translate(IReadOnlyList<int> values);
+        string? Translate(IReadOnlyList<int> values);
     }
 
     /// <summary>
@@ -52,7 +50,7 @@ namespace PoESkillTree.Engine.GameModel.StatTranslation
         /// </returns>
         /// <exception cref="ArgumentException">if the number of values does not match the number of 
         /// <see cref="Ids"/></exception>
-        public string Translate(IReadOnlyList<int> values)
+        public string? Translate(IReadOnlyList<int> values)
         {
             if (values.Count != Ids.Count)
                 throw new ArgumentException("Number of values does not match number of ids");
@@ -105,8 +103,7 @@ namespace PoESkillTree.Engine.GameModel.StatTranslation
         /// <returns>the translated values. Null if the values should not be translated, e.g. the stat should be 
         /// hidden. This is the case for stats without effect or stats that are not meant to be visible to players.
         /// </returns>
-        [CanBeNull]
-        public string Translate(IReadOnlyDictionary<string, int> idValueDict)
+        public string? Translate(IReadOnlyDictionary<string, int> idValueDict)
         {
             var values = new int[Ids.Count];
             for (var i = 0; i < Ids.Count; i++)

--- a/PoESkillTree.Engine.Utils/Extensions/CollectionExtensions.cs
+++ b/PoESkillTree.Engine.Utils/Extensions/CollectionExtensions.cs
@@ -18,12 +18,14 @@ namespace PoESkillTree.Engine.Utils.Extensions
             return value;
         }
 
+#if NETSTANDARD2_0
         public static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> pair,
             out TKey key, out TValue value)
         {
             key = pair.Key;
             value = pair.Value;
         }
+#endif
 
         public static void Deconstruct<TKey, TValue>(this IGrouping<TKey, TValue> pair,
             out TKey key, out IEnumerable<TValue> value)

--- a/PoESkillTree.Engine.Utils/Extensions/CollectionExtensions.cs
+++ b/PoESkillTree.Engine.Utils/Extensions/CollectionExtensions.cs
@@ -67,5 +67,10 @@ namespace PoESkillTree.Engine.Utils.Extensions
             }
             return results;
         }
+
+        public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> @this) where T : class
+#pragma warning disable 8619 // Where clause guarantuees non-null values
+            => @this.Where(t => t != null);
+#pragma warning restore
     }
 }

--- a/PoESkillTree.Engine.Utils/Extensions/EnumerableExtensions.cs
+++ b/PoESkillTree.Engine.Utils/Extensions/EnumerableExtensions.cs
@@ -39,7 +39,10 @@ namespace PoESkillTree.Engine.Utils.Extensions
 
             for (var i = 0; i < @this.Count; i++)
             {
-                if (!@this[i].Equals(other[i]))
+                var thisI = @this[i];
+                if (thisI is null)
+                    return other[i] is null;
+                if (!thisI.Equals(other[i]))
                     return false;
             }
 

--- a/PoESkillTree.Engine.Utils/Extensions/NullableExtensions.cs
+++ b/PoESkillTree.Engine.Utils/Extensions/NullableExtensions.cs
@@ -12,7 +12,7 @@ namespace PoESkillTree.Engine.Utils.Extensions
             return nullable.HasValue ? selector(nullable.Value) : (TOut?) null;
         }
 
-        public static T? AggregateOnValues<T>(this List<T?> values, Func<T, T, T> combiner, Func<T, T> selector = null)
+        public static T? AggregateOnValues<T>(this List<T?> values, Func<T, T, T> combiner, Func<T, T>? selector = null)
             where T: struct
         {
             T? result = null;

--- a/PoESkillTree.Engine.Utils/PoESkillTree.Engine.Utils.csproj
+++ b/PoESkillTree.Engine.Utils/PoESkillTree.Engine.Utils.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Version>1.0.0</Version>
     <FileVersion>1.0.0.0</FileVersion>

--- a/PoESkillTree.Engine.Utils/PoESkillTree.Engine.Utils.csproj
+++ b/PoESkillTree.Engine.Utils/PoESkillTree.Engine.Utils.csproj
@@ -33,5 +33,9 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All" />
     <PackageReference Include="morelinq" Version="3.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Nullable" Version="1.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/PoESkillTree.Engine.Utils/PoESkillTree.Engine.Utils.csproj
+++ b/PoESkillTree.Engine.Utils/PoESkillTree.Engine.Utils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8</LangVersion>
     <Version>1.0.0</Version>
     <FileVersion>1.0.0.0</FileVersion>
 
@@ -17,6 +17,11 @@
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSources>true</IncludeSources>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <WarningsAsErrors>8600;8601;8602;8603;8604;8613;8619;8620;8625</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="LibLog" Version="5.0.6">
@@ -25,7 +30,6 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All" />
     <PackageReference Include="morelinq" Version="3.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />

--- a/PoESkillTree.Engine.Utils/ValueObject.cs
+++ b/PoESkillTree.Engine.Utils/ValueObject.cs
@@ -8,7 +8,7 @@ namespace PoESkillTree.Engine.Utils
     public abstract class ValueObject
     {
         private readonly bool _cacheTupleAndHashCode;
-        private object _tuple;
+        private object? _tuple;
         private int? _hashCode;
 
         protected ValueObject(bool cacheTupleAndHashCode = false)
@@ -25,8 +25,8 @@ namespace PoESkillTree.Engine.Utils
         {
             if (!_cacheTupleAndHashCode)
                 return GetTuple().GetHashCode();
-            // ReSharper disable twice NonReadonlyMemberInGetHashCode It's the cache, of course it's not readonly
-            return _hashCode ?? (_hashCode = GetTuple().GetHashCode()).Value;
+            // ReSharper disable once NonReadonlyMemberInGetHashCode It's the cache, of course it's not readonly
+            return _hashCode ??= GetTuple().GetHashCode();
         }
 
         public override string ToString() => GetTuple().ToString();
@@ -35,7 +35,7 @@ namespace PoESkillTree.Engine.Utils
         {
             if (!_cacheTupleAndHashCode)
                 return ToTuple();
-            return _tuple ?? (_tuple = ToTuple());
+            return _tuple ??= ToTuple();
         }
 
         /// <summary>

--- a/PoESkillTree.Engine.Utils/WikiApi/ApiAccessor.cs
+++ b/PoESkillTree.Engine.Utils/WikiApi/ApiAccessor.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 using MoreLinq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -67,8 +66,7 @@ namespace PoESkillTree.Engine.Utils.WikiApi
             return BaseUri + queryString;
         }
 
-        [ItemCanBeNull]
-        private async Task<JObject> CargoQueryAsync(string uri)
+        private async Task<JObject?> CargoQueryAsync(string uri)
         {
             try
             {

--- a/PoESkillTree.Engine/PoESkillTree.Engine.csproj
+++ b/PoESkillTree.Engine/PoESkillTree.Engine.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Version>1.0.0</Version>
     <FileVersion>1.0.0.0</FileVersion>

--- a/PoESkillTree.Engine/PoESkillTree.Engine.csproj
+++ b/PoESkillTree.Engine/PoESkillTree.Engine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8</LangVersion>
     <Version>1.0.0</Version>
     <FileVersion>1.0.0.0</FileVersion>
 

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ This repository contains the game model and computation engine used for [PoESkil
 
 The goal is to develop this into a general .NET Standard library for Path of Exile build calculations (e.g. DPS) every interested developer can use and contribute to. Currently, the library is optimized for a GUI application with small incremental build changes. I will later add benchmarks for the one-off scenario where you want to input a build, get statistics as outputs and then input the next build. Those will serve as further example usages.
 
-The libraries target .NET Standard 2.0, Console and the test projects .NET Core 2.2.
+The libraries target .NET Standard 2.0 and .NET Standard 2.1, Console and the test projects .NET Core 3.0.


### PR DESCRIPTION
To get support for those, add .NET Standard 2.1 target for library projects and target .NET Core 3.0 for tests and console projects.

Enable nullable reference types and add annotations in all projects.